### PR TITLE
Fix link to icons page

### DIFF
--- a/www/src/pages/icons/index.mdx
+++ b/www/src/pages/icons/index.mdx
@@ -16,7 +16,7 @@ already logged into Okta you’ll be asked to enter your credentials before you 
 
 <ThemedLink
     theme="secondary"
-    to="https://thumbprint.design/icons/"
+    to="https://thumbprint.design/api/icons/"
     icon={<ContentModifierLockedSmall />}
 >
     Open Thumbprint Icons


### PR DESCRIPTION
This page is currently linking to itself. This isn't the proper fix but will unblock people looking for icons.