### PR TITLE
Updating layout, now left aligned

### DIFF
--- a/www/src/components/wrap/index.jsx
+++ b/www/src/components/wrap/index.jsx
@@ -6,7 +6,6 @@ import styles from './index.module.scss';
 const Wrap = ({ hasPadding, children }) => (
     <div
         className={classNames(styles.wrap, {
-            'ph4 l_ph6 center': true,
             l_pv6: hasPadding,
         })}
         data-algolia="content"

--- a/www/src/components/wrap/index.module.scss
+++ b/www/src/components/wrap/index.module.scss
@@ -2,5 +2,12 @@
 @import '~@thumbtack/tp-ui-core-mixin/_index';
 
 .wrap {
-    max-width: 960px;
+    max-width: 1024px;
+    padding-left: $tp-space__4;
+    padding-right: $tp-space__4;
+
+    @include tp-respond-above($tp-breakpoint__large) {
+        padding-left: 96px;
+        padding-right: 96px;
+    }
 }


### PR DESCRIPTION
Removes the centering of the content in favor of left-aligned with wider padding values at the large size.