### PR TITLE
Update failing Jest snapshot

### DIFF
--- a/packages/thumbprint-react/components/StarRating/__snapshots__/test.jsx.snap
+++ b/packages/thumbprint-react/components/StarRating/__snapshots__/test.jsx.snap
@@ -24,7 +24,6 @@ exports[`does not add title text if a function is provided 1`] = `
         className="starSVG starSVGSizeSmall"
         fill="#febe14"
         height="16"
-        viewBox="0 0 16 16"
         width="16"
         xmlns="http://www.w3.org/2000/svg"
       />
@@ -39,7 +38,6 @@ exports[`does not add title text if a function is provided 1`] = `
         className="starSVG starSVGSizeSmall"
         fill="#febe14"
         height="16"
-        viewBox="0 0 16 16"
         width="16"
         xmlns="http://www.w3.org/2000/svg"
       />
@@ -54,7 +52,6 @@ exports[`does not add title text if a function is provided 1`] = `
         className="starSVG starSVGSizeSmall"
         fill="#febe14"
         height="16"
-        viewBox="0 0 16 16"
         width="16"
         xmlns="http://www.w3.org/2000/svg"
       />
@@ -69,7 +66,6 @@ exports[`does not add title text if a function is provided 1`] = `
         className="starSVG starSVGSizeSmall"
         fill="#febe14"
         height="16"
-        viewBox="0 0 16 16"
         width="16"
         xmlns="http://www.w3.org/2000/svg"
       />
@@ -84,7 +80,6 @@ exports[`does not add title text if a function is provided 1`] = `
         className="starSVG starSVGSizeSmall"
         fill="#febe14"
         height="16"
-        viewBox="0 0 16 16"
         width="16"
         xmlns="http://www.w3.org/2000/svg"
       />
@@ -105,7 +100,6 @@ exports[`does not add title text if a function is provided 1`] = `
         className="starSVG starSVGSizeSmall"
         fill="#d3d4d5"
         height="16"
-        viewBox="0 0 16 16"
         width="16"
         xmlns="http://www.w3.org/2000/svg"
       />
@@ -120,7 +114,6 @@ exports[`does not add title text if a function is provided 1`] = `
         className="starSVG starSVGSizeSmall"
         fill="#d3d4d5"
         height="16"
-        viewBox="0 0 16 16"
         width="16"
         xmlns="http://www.w3.org/2000/svg"
       />
@@ -135,7 +128,6 @@ exports[`does not add title text if a function is provided 1`] = `
         className="starSVG starSVGSizeSmall"
         fill="#d3d4d5"
         height="16"
-        viewBox="0 0 16 16"
         width="16"
         xmlns="http://www.w3.org/2000/svg"
       />
@@ -150,7 +142,6 @@ exports[`does not add title text if a function is provided 1`] = `
         className="starSVG starSVGSizeSmall"
         fill="#d3d4d5"
         height="16"
-        viewBox="0 0 16 16"
         width="16"
         xmlns="http://www.w3.org/2000/svg"
       />
@@ -165,7 +156,6 @@ exports[`does not add title text if a function is provided 1`] = `
         className="starSVG starSVGSizeSmall"
         fill="#d3d4d5"
         height="16"
-        viewBox="0 0 16 16"
         width="16"
         xmlns="http://www.w3.org/2000/svg"
       />
@@ -199,7 +189,6 @@ exports[`generates the correct title 1`] = `
         className="starSVG starSVGSizeSmall"
         fill="#febe14"
         height="16"
-        viewBox="0 0 16 16"
         width="16"
         xmlns="http://www.w3.org/2000/svg"
       />
@@ -214,7 +203,6 @@ exports[`generates the correct title 1`] = `
         className="starSVG starSVGSizeSmall"
         fill="#febe14"
         height="16"
-        viewBox="0 0 16 16"
         width="16"
         xmlns="http://www.w3.org/2000/svg"
       />
@@ -229,7 +217,6 @@ exports[`generates the correct title 1`] = `
         className="starSVG starSVGSizeSmall"
         fill="#febe14"
         height="16"
-        viewBox="0 0 16 16"
         width="16"
         xmlns="http://www.w3.org/2000/svg"
       />
@@ -244,7 +231,6 @@ exports[`generates the correct title 1`] = `
         className="starSVG starSVGSizeSmall"
         fill="#febe14"
         height="16"
-        viewBox="0 0 16 16"
         width="16"
         xmlns="http://www.w3.org/2000/svg"
       />
@@ -259,7 +245,6 @@ exports[`generates the correct title 1`] = `
         className="starSVG starSVGSizeSmall"
         fill="#febe14"
         height="16"
-        viewBox="0 0 16 16"
         width="16"
         xmlns="http://www.w3.org/2000/svg"
       />
@@ -280,7 +265,6 @@ exports[`generates the correct title 1`] = `
         className="starSVG starSVGSizeSmall"
         fill="#d3d4d5"
         height="16"
-        viewBox="0 0 16 16"
         width="16"
         xmlns="http://www.w3.org/2000/svg"
       />
@@ -295,7 +279,6 @@ exports[`generates the correct title 1`] = `
         className="starSVG starSVGSizeSmall"
         fill="#d3d4d5"
         height="16"
-        viewBox="0 0 16 16"
         width="16"
         xmlns="http://www.w3.org/2000/svg"
       />
@@ -310,7 +293,6 @@ exports[`generates the correct title 1`] = `
         className="starSVG starSVGSizeSmall"
         fill="#d3d4d5"
         height="16"
-        viewBox="0 0 16 16"
         width="16"
         xmlns="http://www.w3.org/2000/svg"
       />
@@ -325,7 +307,6 @@ exports[`generates the correct title 1`] = `
         className="starSVG starSVGSizeSmall"
         fill="#d3d4d5"
         height="16"
-        viewBox="0 0 16 16"
         width="16"
         xmlns="http://www.w3.org/2000/svg"
       />
@@ -340,7 +321,6 @@ exports[`generates the correct title 1`] = `
         className="starSVG starSVGSizeSmall"
         fill="#d3d4d5"
         height="16"
-        viewBox="0 0 16 16"
         width="16"
         xmlns="http://www.w3.org/2000/svg"
       />
@@ -382,7 +362,6 @@ exports[`renders 0 star rating 1`] = `
           className="starSVG starSVGSizeSmall"
           fill="#febe14"
           height="16"
-          viewBox="0 0 16 16"
           width="16"
           xmlns="http://www.w3.org/2000/svg"
         >
@@ -390,7 +369,6 @@ exports[`renders 0 star rating 1`] = `
             className="starSVG starSVGSizeSmall"
             fill="#febe14"
             height="16"
-            viewBox="0 0 16 16"
             width="16"
             xmlns="http://www.w3.org/2000/svg"
           >
@@ -410,7 +388,6 @@ exports[`renders 0 star rating 1`] = `
           className="starSVG starSVGSizeSmall"
           fill="#febe14"
           height="16"
-          viewBox="0 0 16 16"
           width="16"
           xmlns="http://www.w3.org/2000/svg"
         >
@@ -418,7 +395,6 @@ exports[`renders 0 star rating 1`] = `
             className="starSVG starSVGSizeSmall"
             fill="#febe14"
             height="16"
-            viewBox="0 0 16 16"
             width="16"
             xmlns="http://www.w3.org/2000/svg"
           >
@@ -438,7 +414,6 @@ exports[`renders 0 star rating 1`] = `
           className="starSVG starSVGSizeSmall"
           fill="#febe14"
           height="16"
-          viewBox="0 0 16 16"
           width="16"
           xmlns="http://www.w3.org/2000/svg"
         >
@@ -446,7 +421,6 @@ exports[`renders 0 star rating 1`] = `
             className="starSVG starSVGSizeSmall"
             fill="#febe14"
             height="16"
-            viewBox="0 0 16 16"
             width="16"
             xmlns="http://www.w3.org/2000/svg"
           >
@@ -466,7 +440,6 @@ exports[`renders 0 star rating 1`] = `
           className="starSVG starSVGSizeSmall"
           fill="#febe14"
           height="16"
-          viewBox="0 0 16 16"
           width="16"
           xmlns="http://www.w3.org/2000/svg"
         >
@@ -474,7 +447,6 @@ exports[`renders 0 star rating 1`] = `
             className="starSVG starSVGSizeSmall"
             fill="#febe14"
             height="16"
-            viewBox="0 0 16 16"
             width="16"
             xmlns="http://www.w3.org/2000/svg"
           >
@@ -494,7 +466,6 @@ exports[`renders 0 star rating 1`] = `
           className="starSVG starSVGSizeSmall"
           fill="#febe14"
           height="16"
-          viewBox="0 0 16 16"
           width="16"
           xmlns="http://www.w3.org/2000/svg"
         >
@@ -502,7 +473,6 @@ exports[`renders 0 star rating 1`] = `
             className="starSVG starSVGSizeSmall"
             fill="#febe14"
             height="16"
-            viewBox="0 0 16 16"
             width="16"
             xmlns="http://www.w3.org/2000/svg"
           >
@@ -528,7 +498,6 @@ exports[`renders 0 star rating 1`] = `
           className="starSVG starSVGSizeSmall"
           fill="#d3d4d5"
           height="16"
-          viewBox="0 0 16 16"
           width="16"
           xmlns="http://www.w3.org/2000/svg"
         >
@@ -536,7 +505,6 @@ exports[`renders 0 star rating 1`] = `
             className="starSVG starSVGSizeSmall"
             fill="#d3d4d5"
             height="16"
-            viewBox="0 0 16 16"
             width="16"
             xmlns="http://www.w3.org/2000/svg"
           >
@@ -556,7 +524,6 @@ exports[`renders 0 star rating 1`] = `
           className="starSVG starSVGSizeSmall"
           fill="#d3d4d5"
           height="16"
-          viewBox="0 0 16 16"
           width="16"
           xmlns="http://www.w3.org/2000/svg"
         >
@@ -564,7 +531,6 @@ exports[`renders 0 star rating 1`] = `
             className="starSVG starSVGSizeSmall"
             fill="#d3d4d5"
             height="16"
-            viewBox="0 0 16 16"
             width="16"
             xmlns="http://www.w3.org/2000/svg"
           >
@@ -584,7 +550,6 @@ exports[`renders 0 star rating 1`] = `
           className="starSVG starSVGSizeSmall"
           fill="#d3d4d5"
           height="16"
-          viewBox="0 0 16 16"
           width="16"
           xmlns="http://www.w3.org/2000/svg"
         >
@@ -592,7 +557,6 @@ exports[`renders 0 star rating 1`] = `
             className="starSVG starSVGSizeSmall"
             fill="#d3d4d5"
             height="16"
-            viewBox="0 0 16 16"
             width="16"
             xmlns="http://www.w3.org/2000/svg"
           >
@@ -612,7 +576,6 @@ exports[`renders 0 star rating 1`] = `
           className="starSVG starSVGSizeSmall"
           fill="#d3d4d5"
           height="16"
-          viewBox="0 0 16 16"
           width="16"
           xmlns="http://www.w3.org/2000/svg"
         >
@@ -620,7 +583,6 @@ exports[`renders 0 star rating 1`] = `
             className="starSVG starSVGSizeSmall"
             fill="#d3d4d5"
             height="16"
-            viewBox="0 0 16 16"
             width="16"
             xmlns="http://www.w3.org/2000/svg"
           >
@@ -640,7 +602,6 @@ exports[`renders 0 star rating 1`] = `
           className="starSVG starSVGSizeSmall"
           fill="#d3d4d5"
           height="16"
-          viewBox="0 0 16 16"
           width="16"
           xmlns="http://www.w3.org/2000/svg"
         >
@@ -648,7 +609,6 @@ exports[`renders 0 star rating 1`] = `
             className="starSVG starSVGSizeSmall"
             fill="#d3d4d5"
             height="16"
-            viewBox="0 0 16 16"
             width="16"
             xmlns="http://www.w3.org/2000/svg"
           >
@@ -696,7 +656,6 @@ exports[`renders 2.5 star rating 1`] = `
           className="starSVG starSVGSizeSmall"
           fill="#febe14"
           height="16"
-          viewBox="0 0 16 16"
           width="16"
           xmlns="http://www.w3.org/2000/svg"
         >
@@ -704,7 +663,6 @@ exports[`renders 2.5 star rating 1`] = `
             className="starSVG starSVGSizeSmall"
             fill="#febe14"
             height="16"
-            viewBox="0 0 16 16"
             width="16"
             xmlns="http://www.w3.org/2000/svg"
           >
@@ -724,7 +682,6 @@ exports[`renders 2.5 star rating 1`] = `
           className="starSVG starSVGSizeSmall"
           fill="#febe14"
           height="16"
-          viewBox="0 0 16 16"
           width="16"
           xmlns="http://www.w3.org/2000/svg"
         >
@@ -732,7 +689,6 @@ exports[`renders 2.5 star rating 1`] = `
             className="starSVG starSVGSizeSmall"
             fill="#febe14"
             height="16"
-            viewBox="0 0 16 16"
             width="16"
             xmlns="http://www.w3.org/2000/svg"
           >
@@ -752,7 +708,6 @@ exports[`renders 2.5 star rating 1`] = `
           className="starSVG starSVGSizeSmall"
           fill="#febe14"
           height="16"
-          viewBox="0 0 16 16"
           width="16"
           xmlns="http://www.w3.org/2000/svg"
         >
@@ -760,7 +715,6 @@ exports[`renders 2.5 star rating 1`] = `
             className="starSVG starSVGSizeSmall"
             fill="#febe14"
             height="16"
-            viewBox="0 0 16 16"
             width="16"
             xmlns="http://www.w3.org/2000/svg"
           >
@@ -780,7 +734,6 @@ exports[`renders 2.5 star rating 1`] = `
           className="starSVG starSVGSizeSmall"
           fill="#febe14"
           height="16"
-          viewBox="0 0 16 16"
           width="16"
           xmlns="http://www.w3.org/2000/svg"
         >
@@ -788,7 +741,6 @@ exports[`renders 2.5 star rating 1`] = `
             className="starSVG starSVGSizeSmall"
             fill="#febe14"
             height="16"
-            viewBox="0 0 16 16"
             width="16"
             xmlns="http://www.w3.org/2000/svg"
           >
@@ -808,7 +760,6 @@ exports[`renders 2.5 star rating 1`] = `
           className="starSVG starSVGSizeSmall"
           fill="#febe14"
           height="16"
-          viewBox="0 0 16 16"
           width="16"
           xmlns="http://www.w3.org/2000/svg"
         >
@@ -816,7 +767,6 @@ exports[`renders 2.5 star rating 1`] = `
             className="starSVG starSVGSizeSmall"
             fill="#febe14"
             height="16"
-            viewBox="0 0 16 16"
             width="16"
             xmlns="http://www.w3.org/2000/svg"
           >
@@ -842,7 +792,6 @@ exports[`renders 2.5 star rating 1`] = `
           className="starSVG starSVGSizeSmall"
           fill="#d3d4d5"
           height="16"
-          viewBox="0 0 16 16"
           width="16"
           xmlns="http://www.w3.org/2000/svg"
         >
@@ -850,7 +799,6 @@ exports[`renders 2.5 star rating 1`] = `
             className="starSVG starSVGSizeSmall"
             fill="#d3d4d5"
             height="16"
-            viewBox="0 0 16 16"
             width="16"
             xmlns="http://www.w3.org/2000/svg"
           >
@@ -870,7 +818,6 @@ exports[`renders 2.5 star rating 1`] = `
           className="starSVG starSVGSizeSmall"
           fill="#d3d4d5"
           height="16"
-          viewBox="0 0 16 16"
           width="16"
           xmlns="http://www.w3.org/2000/svg"
         >
@@ -878,7 +825,6 @@ exports[`renders 2.5 star rating 1`] = `
             className="starSVG starSVGSizeSmall"
             fill="#d3d4d5"
             height="16"
-            viewBox="0 0 16 16"
             width="16"
             xmlns="http://www.w3.org/2000/svg"
           >
@@ -898,7 +844,6 @@ exports[`renders 2.5 star rating 1`] = `
           className="starSVG starSVGSizeSmall"
           fill="#d3d4d5"
           height="16"
-          viewBox="0 0 16 16"
           width="16"
           xmlns="http://www.w3.org/2000/svg"
         >
@@ -906,7 +851,6 @@ exports[`renders 2.5 star rating 1`] = `
             className="starSVG starSVGSizeSmall"
             fill="#d3d4d5"
             height="16"
-            viewBox="0 0 16 16"
             width="16"
             xmlns="http://www.w3.org/2000/svg"
           >
@@ -926,7 +870,6 @@ exports[`renders 2.5 star rating 1`] = `
           className="starSVG starSVGSizeSmall"
           fill="#d3d4d5"
           height="16"
-          viewBox="0 0 16 16"
           width="16"
           xmlns="http://www.w3.org/2000/svg"
         >
@@ -934,7 +877,6 @@ exports[`renders 2.5 star rating 1`] = `
             className="starSVG starSVGSizeSmall"
             fill="#d3d4d5"
             height="16"
-            viewBox="0 0 16 16"
             width="16"
             xmlns="http://www.w3.org/2000/svg"
           >
@@ -954,7 +896,6 @@ exports[`renders 2.5 star rating 1`] = `
           className="starSVG starSVGSizeSmall"
           fill="#d3d4d5"
           height="16"
-          viewBox="0 0 16 16"
           width="16"
           xmlns="http://www.w3.org/2000/svg"
         >
@@ -962,7 +903,6 @@ exports[`renders 2.5 star rating 1`] = `
             className="starSVG starSVGSizeSmall"
             fill="#d3d4d5"
             height="16"
-            viewBox="0 0 16 16"
             width="16"
             xmlns="http://www.w3.org/2000/svg"
           >
@@ -1010,7 +950,6 @@ exports[`renders 3 star rating 1`] = `
           className="starSVG starSVGSizeSmall"
           fill="#febe14"
           height="16"
-          viewBox="0 0 16 16"
           width="16"
           xmlns="http://www.w3.org/2000/svg"
         >
@@ -1018,7 +957,6 @@ exports[`renders 3 star rating 1`] = `
             className="starSVG starSVGSizeSmall"
             fill="#febe14"
             height="16"
-            viewBox="0 0 16 16"
             width="16"
             xmlns="http://www.w3.org/2000/svg"
           >
@@ -1038,7 +976,6 @@ exports[`renders 3 star rating 1`] = `
           className="starSVG starSVGSizeSmall"
           fill="#febe14"
           height="16"
-          viewBox="0 0 16 16"
           width="16"
           xmlns="http://www.w3.org/2000/svg"
         >
@@ -1046,7 +983,6 @@ exports[`renders 3 star rating 1`] = `
             className="starSVG starSVGSizeSmall"
             fill="#febe14"
             height="16"
-            viewBox="0 0 16 16"
             width="16"
             xmlns="http://www.w3.org/2000/svg"
           >
@@ -1066,7 +1002,6 @@ exports[`renders 3 star rating 1`] = `
           className="starSVG starSVGSizeSmall"
           fill="#febe14"
           height="16"
-          viewBox="0 0 16 16"
           width="16"
           xmlns="http://www.w3.org/2000/svg"
         >
@@ -1074,7 +1009,6 @@ exports[`renders 3 star rating 1`] = `
             className="starSVG starSVGSizeSmall"
             fill="#febe14"
             height="16"
-            viewBox="0 0 16 16"
             width="16"
             xmlns="http://www.w3.org/2000/svg"
           >
@@ -1094,7 +1028,6 @@ exports[`renders 3 star rating 1`] = `
           className="starSVG starSVGSizeSmall"
           fill="#febe14"
           height="16"
-          viewBox="0 0 16 16"
           width="16"
           xmlns="http://www.w3.org/2000/svg"
         >
@@ -1102,7 +1035,6 @@ exports[`renders 3 star rating 1`] = `
             className="starSVG starSVGSizeSmall"
             fill="#febe14"
             height="16"
-            viewBox="0 0 16 16"
             width="16"
             xmlns="http://www.w3.org/2000/svg"
           >
@@ -1122,7 +1054,6 @@ exports[`renders 3 star rating 1`] = `
           className="starSVG starSVGSizeSmall"
           fill="#febe14"
           height="16"
-          viewBox="0 0 16 16"
           width="16"
           xmlns="http://www.w3.org/2000/svg"
         >
@@ -1130,7 +1061,6 @@ exports[`renders 3 star rating 1`] = `
             className="starSVG starSVGSizeSmall"
             fill="#febe14"
             height="16"
-            viewBox="0 0 16 16"
             width="16"
             xmlns="http://www.w3.org/2000/svg"
           >
@@ -1156,7 +1086,6 @@ exports[`renders 3 star rating 1`] = `
           className="starSVG starSVGSizeSmall"
           fill="#d3d4d5"
           height="16"
-          viewBox="0 0 16 16"
           width="16"
           xmlns="http://www.w3.org/2000/svg"
         >
@@ -1164,7 +1093,6 @@ exports[`renders 3 star rating 1`] = `
             className="starSVG starSVGSizeSmall"
             fill="#d3d4d5"
             height="16"
-            viewBox="0 0 16 16"
             width="16"
             xmlns="http://www.w3.org/2000/svg"
           >
@@ -1184,7 +1112,6 @@ exports[`renders 3 star rating 1`] = `
           className="starSVG starSVGSizeSmall"
           fill="#d3d4d5"
           height="16"
-          viewBox="0 0 16 16"
           width="16"
           xmlns="http://www.w3.org/2000/svg"
         >
@@ -1192,7 +1119,6 @@ exports[`renders 3 star rating 1`] = `
             className="starSVG starSVGSizeSmall"
             fill="#d3d4d5"
             height="16"
-            viewBox="0 0 16 16"
             width="16"
             xmlns="http://www.w3.org/2000/svg"
           >
@@ -1212,7 +1138,6 @@ exports[`renders 3 star rating 1`] = `
           className="starSVG starSVGSizeSmall"
           fill="#d3d4d5"
           height="16"
-          viewBox="0 0 16 16"
           width="16"
           xmlns="http://www.w3.org/2000/svg"
         >
@@ -1220,7 +1145,6 @@ exports[`renders 3 star rating 1`] = `
             className="starSVG starSVGSizeSmall"
             fill="#d3d4d5"
             height="16"
-            viewBox="0 0 16 16"
             width="16"
             xmlns="http://www.w3.org/2000/svg"
           >
@@ -1240,7 +1164,6 @@ exports[`renders 3 star rating 1`] = `
           className="starSVG starSVGSizeSmall"
           fill="#d3d4d5"
           height="16"
-          viewBox="0 0 16 16"
           width="16"
           xmlns="http://www.w3.org/2000/svg"
         >
@@ -1248,7 +1171,6 @@ exports[`renders 3 star rating 1`] = `
             className="starSVG starSVGSizeSmall"
             fill="#d3d4d5"
             height="16"
-            viewBox="0 0 16 16"
             width="16"
             xmlns="http://www.w3.org/2000/svg"
           >
@@ -1268,7 +1190,6 @@ exports[`renders 3 star rating 1`] = `
           className="starSVG starSVGSizeSmall"
           fill="#d3d4d5"
           height="16"
-          viewBox="0 0 16 16"
           width="16"
           xmlns="http://www.w3.org/2000/svg"
         >
@@ -1276,7 +1197,6 @@ exports[`renders 3 star rating 1`] = `
             className="starSVG starSVGSizeSmall"
             fill="#d3d4d5"
             height="16"
-            viewBox="0 0 16 16"
             width="16"
             xmlns="http://www.w3.org/2000/svg"
           >
@@ -1324,7 +1244,6 @@ exports[`renders 10 star SVG elements in total 1`] = `
           className="starSVG starSVGSizeSmall"
           fill="#febe14"
           height="16"
-          viewBox="0 0 16 16"
           width="16"
           xmlns="http://www.w3.org/2000/svg"
         >
@@ -1332,7 +1251,6 @@ exports[`renders 10 star SVG elements in total 1`] = `
             className="starSVG starSVGSizeSmall"
             fill="#febe14"
             height="16"
-            viewBox="0 0 16 16"
             width="16"
             xmlns="http://www.w3.org/2000/svg"
           >
@@ -1352,7 +1270,6 @@ exports[`renders 10 star SVG elements in total 1`] = `
           className="starSVG starSVGSizeSmall"
           fill="#febe14"
           height="16"
-          viewBox="0 0 16 16"
           width="16"
           xmlns="http://www.w3.org/2000/svg"
         >
@@ -1360,7 +1277,6 @@ exports[`renders 10 star SVG elements in total 1`] = `
             className="starSVG starSVGSizeSmall"
             fill="#febe14"
             height="16"
-            viewBox="0 0 16 16"
             width="16"
             xmlns="http://www.w3.org/2000/svg"
           >
@@ -1380,7 +1296,6 @@ exports[`renders 10 star SVG elements in total 1`] = `
           className="starSVG starSVGSizeSmall"
           fill="#febe14"
           height="16"
-          viewBox="0 0 16 16"
           width="16"
           xmlns="http://www.w3.org/2000/svg"
         >
@@ -1388,7 +1303,6 @@ exports[`renders 10 star SVG elements in total 1`] = `
             className="starSVG starSVGSizeSmall"
             fill="#febe14"
             height="16"
-            viewBox="0 0 16 16"
             width="16"
             xmlns="http://www.w3.org/2000/svg"
           >
@@ -1408,7 +1322,6 @@ exports[`renders 10 star SVG elements in total 1`] = `
           className="starSVG starSVGSizeSmall"
           fill="#febe14"
           height="16"
-          viewBox="0 0 16 16"
           width="16"
           xmlns="http://www.w3.org/2000/svg"
         >
@@ -1416,7 +1329,6 @@ exports[`renders 10 star SVG elements in total 1`] = `
             className="starSVG starSVGSizeSmall"
             fill="#febe14"
             height="16"
-            viewBox="0 0 16 16"
             width="16"
             xmlns="http://www.w3.org/2000/svg"
           >
@@ -1436,7 +1348,6 @@ exports[`renders 10 star SVG elements in total 1`] = `
           className="starSVG starSVGSizeSmall"
           fill="#febe14"
           height="16"
-          viewBox="0 0 16 16"
           width="16"
           xmlns="http://www.w3.org/2000/svg"
         >
@@ -1444,7 +1355,6 @@ exports[`renders 10 star SVG elements in total 1`] = `
             className="starSVG starSVGSizeSmall"
             fill="#febe14"
             height="16"
-            viewBox="0 0 16 16"
             width="16"
             xmlns="http://www.w3.org/2000/svg"
           >
@@ -1470,7 +1380,6 @@ exports[`renders 10 star SVG elements in total 1`] = `
           className="starSVG starSVGSizeSmall"
           fill="#d3d4d5"
           height="16"
-          viewBox="0 0 16 16"
           width="16"
           xmlns="http://www.w3.org/2000/svg"
         >
@@ -1478,7 +1387,6 @@ exports[`renders 10 star SVG elements in total 1`] = `
             className="starSVG starSVGSizeSmall"
             fill="#d3d4d5"
             height="16"
-            viewBox="0 0 16 16"
             width="16"
             xmlns="http://www.w3.org/2000/svg"
           >
@@ -1498,7 +1406,6 @@ exports[`renders 10 star SVG elements in total 1`] = `
           className="starSVG starSVGSizeSmall"
           fill="#d3d4d5"
           height="16"
-          viewBox="0 0 16 16"
           width="16"
           xmlns="http://www.w3.org/2000/svg"
         >
@@ -1506,7 +1413,6 @@ exports[`renders 10 star SVG elements in total 1`] = `
             className="starSVG starSVGSizeSmall"
             fill="#d3d4d5"
             height="16"
-            viewBox="0 0 16 16"
             width="16"
             xmlns="http://www.w3.org/2000/svg"
           >
@@ -1526,7 +1432,6 @@ exports[`renders 10 star SVG elements in total 1`] = `
           className="starSVG starSVGSizeSmall"
           fill="#d3d4d5"
           height="16"
-          viewBox="0 0 16 16"
           width="16"
           xmlns="http://www.w3.org/2000/svg"
         >
@@ -1534,7 +1439,6 @@ exports[`renders 10 star SVG elements in total 1`] = `
             className="starSVG starSVGSizeSmall"
             fill="#d3d4d5"
             height="16"
-            viewBox="0 0 16 16"
             width="16"
             xmlns="http://www.w3.org/2000/svg"
           >
@@ -1554,7 +1458,6 @@ exports[`renders 10 star SVG elements in total 1`] = `
           className="starSVG starSVGSizeSmall"
           fill="#d3d4d5"
           height="16"
-          viewBox="0 0 16 16"
           width="16"
           xmlns="http://www.w3.org/2000/svg"
         >
@@ -1562,7 +1465,6 @@ exports[`renders 10 star SVG elements in total 1`] = `
             className="starSVG starSVGSizeSmall"
             fill="#d3d4d5"
             height="16"
-            viewBox="0 0 16 16"
             width="16"
             xmlns="http://www.w3.org/2000/svg"
           >
@@ -1582,7 +1484,6 @@ exports[`renders 10 star SVG elements in total 1`] = `
           className="starSVG starSVGSizeSmall"
           fill="#d3d4d5"
           height="16"
-          viewBox="0 0 16 16"
           width="16"
           xmlns="http://www.w3.org/2000/svg"
         >
@@ -1590,7 +1491,6 @@ exports[`renders 10 star SVG elements in total 1`] = `
             className="starSVG starSVGSizeSmall"
             fill="#d3d4d5"
             height="16"
-            viewBox="0 0 16 16"
             width="16"
             xmlns="http://www.w3.org/2000/svg"
           >


### PR DESCRIPTION
This Jest snapshot is failing on CI. After digging into why, I realized that it also starts failing locally once I clear my snapshot with `yarn jest --clearCache`.

This updates the snapshot. Viewbox is getting removed because of this PR:
https://github.com/thumbtack/thumbprint/pull/43/files

SVGO seemed to think that it is not needed.