### PR TITLE
Fix wrapping element for list items

### DIFF
--- a/www/src/components/mdx/index.jsx
+++ b/www/src/components/mdx/index.jsx
@@ -112,7 +112,7 @@ export const Pre = p => <div {...p} />;
 
 export const LI = p => (
     <ListItem>
-        <Text elementName="p" className={`black-300 ${styles.readingWidth}`} {...p} />
+        <Text elementName="div" className={`black-300 ${styles.readingWidth}`} {...p} />
     </ListItem>
 );
 


### PR DESCRIPTION
Fixes console errors like `<div> cannot appear as a descendant of <p>`. To properly handle nested HTML in a list a `<div>` is required.