### PR TITLE
Fix Gatsby warning on local

### DIFF
--- a/www/src/components/page-header/index.jsx
+++ b/www/src/components/page-header/index.jsx
@@ -9,12 +9,8 @@ const PageHeader = ({ metaTitle, description, pageTitle }) => (
     <div className="mb5">
         <Helmet>
             {metaTitle && <title>{metaTitle} / Thumbprint</title>}
-            {description && (
-                <React.Fragment>
-                    <meta name="description" content={description} />
-                    <meta property="og:description" content={description} />
-                </React.Fragment>
-            )}
+            {description && <meta name="description" content={description} />}
+            {description && <meta property="og:description" content={description} />}
         </Helmet>
 
         <ActiveSectionContext.Consumer>


### PR DESCRIPTION
Gatsby and React Helmet don't like the usage of `React.Fragment`. This only breaks when running locally—although I'm not sure why.