### PR TITLE
Bring back accidentally removed `InputRowContext` export.

### DIFF
--- a/packages/thumbprint-react/CHANGELOG.md
+++ b/packages/thumbprint-react/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+-   [Patch] Bring back `InputRowContext` context that was accidentally removed during consolidation into one NPM package. (#8)
+
 ## 0.1.4 - 2019-01-30
 
 ### Changed

--- a/packages/thumbprint-react/components/InputRow/README.mdx
+++ b/packages/thumbprint-react/components/InputRow/README.mdx
@@ -26,7 +26,7 @@ The `InputRow` exports its React context as `InputRowContext`. This makes it pos
 To use `InputRowContext`, start by importing it within your component:
 
 ```js
-import { InputRowContext } from '@thumbtack/tp-ui-react-input-row';
+import { InputRowContext } from '@thumbtack/thumbprint-react';
 ```
 
 Within your component's JSX, you'll use `<InputRowContext.Consumer>` to gain access to three booleans: `isWithinInputRow`, `isFirstInputRowChild`, `isLastInputRowChild`.

--- a/packages/thumbprint-react/index.js
+++ b/packages/thumbprint-react/index.js
@@ -7,7 +7,7 @@ export { default as DatePicker } from './components/DatePicker/index.jsx';
 export { default as FormNote } from './components/FormNote/index.jsx';
 export { Grid, GridColumn } from './components/Grid/index.jsx';
 export { default as Input, InputIcon, InputClearButton } from './components/Input/index.jsx';
-export { default as InputRow } from './components/InputRow/index.jsx';
+export { default as InputRow, InputRowContext } from './components/InputRow/index.jsx';
 export { default as Label } from './components/Label/index.jsx';
 export { default as Link, ThemedLink } from './components/Link/index.jsx';
 export { List, ListItem } from './components/List/index.jsx';


### PR DESCRIPTION
Fixes #8.