### PR TITLE
Fix contents div in ModalDefault with sticky ModalFooter having no height in IE11 (#115)

### DIFF
--- a/packages/thumbprint-react/CHANGELOG.md
+++ b/packages/thumbprint-react/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+-   [Patch] Fix contents div in ModalDefault with sticky ModalFooter having no height in IE11. (#115)
+
 ## 0.2.1 - 2019-02-08
 
 ### Changed

--- a/packages/thumbprint-react/components/ModalDefault/index.module.scss
+++ b/packages/thumbprint-react/components/ModalDefault/index.module.scss
@@ -121,7 +121,7 @@ $width-wide: 1400px;
     }
 
     &Sticky {
-        flex: 1;
+        flex: 1 1 auto;
     }
 }
 


### PR DESCRIPTION
Fixes #115.