### PR TITLE
Use a red border in the `caution` button focus state.

### DIFF
--- a/packages/thumbprint-react/CHANGELOG.md
+++ b/packages/thumbprint-react/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+-   [Patch] Use a red border in the `caution` button focus state. (#116)
+
 ### Fixed
 
 -   [Patch] Fix contents div in ModalDefault with sticky ModalFooter having no height in IE11. (#115)

--- a/packages/thumbprint-react/components/UIAction/themed.module.scss
+++ b/packages/thumbprint-react/components/UIAction/themed.module.scss
@@ -148,7 +148,7 @@ $button-border-width: 2px;
         &:focus {
             color: $tp-color__red-500;
             background-color: $tp-color__white;
-            border-color: $tp-color__gray;
+            border-color: $tp-color__red-500;
         }
     }
 

--- a/packages/thumbprint-scss/CHANGELOG.md
+++ b/packages/thumbprint-scss/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+-   [Patch] Use a red border in the `caution` button focus state. (#116)
+
 ## 0.1.1 - 2019-02-08
 
 ### Changed

--- a/packages/thumbprint-scss/__snapshots__/test.js.snap
+++ b/packages/thumbprint-scss/__snapshots__/test.js.snap
@@ -319,7 +319,7 @@ exports[`compiles correctly 1`] = `
 .tp-button[disabled]:visited.tp-button--caution {
   color: #ffb0b0;
   background-color: #fff;
-  border-color: #d3d4d5;
+  border-color: #cc3553;
 }
 .tp-button--disabled.tp-button--solid,
 .tp-button--disabled:active.tp-button--solid,

--- a/packages/thumbprint-scss/mixins/button.scss
+++ b/packages/thumbprint-scss/mixins/button.scss
@@ -159,7 +159,7 @@
         &.tp-button--caution {
             color: $tp-color__red-300 $important;
             background-color: $tp-color__white $important;
-            border-color: $tp-color__gray $important;
+            border-color: $tp-color__red-500 $important;
         }
 
         &.tp-button--solid {


### PR DESCRIPTION
Fixes #116.