### PR TITLE
Fix file watching/reloading for components

### DIFF
--- a/www/gatsby-node.js
+++ b/www/gatsby-node.js
@@ -22,10 +22,12 @@ exports.onCreateWebpackConfig = ({ actions }) => {
         resolve: {
             modules: [path.resolve(__dirname, 'src'), 'node_modules'],
             alias: {
-                // Use Thumbprint React and SCSS source files when `import`'ing them in the
-                // documentation. By default, Webpack will use the value of the `main` or `module`
-                // field in the package's `package.json` file. This makes it difficult to develop
-                // locally because it'd require running re-compiling the code after each change.
+                // Use Thumbprint React and SCSS source files when `import`'ing
+                // them in the documentation. By default, Webpack will use the
+                // value of the `main` or `module` field in the package's
+                // `package.json` file. This makes it difficult to develop
+                // locally because it'd require running re-compiling the code
+                // after each change.
                 '@thumbtack/thumbprint-react':
                     process.env.NODE_ENV !== 'production'
                         ? path.resolve(__dirname, '../packages/thumbprint-react/index.js')

--- a/www/gatsby-node.js
+++ b/www/gatsby-node.js
@@ -26,8 +26,8 @@ exports.onCreateWebpackConfig = ({ actions }) => {
                 // them in the documentation. By default, Webpack will use the
                 // value of the `main` or `module` field in the package's
                 // `package.json` file. This makes it difficult to develop
-                // locally because it'd require running re-compiling the code
-                // after each change.
+                // locally because it'd require re-compiling the code after
+                // each change.
                 '@thumbtack/thumbprint-react':
                     process.env.NODE_ENV === 'development'
                         ? path.resolve(__dirname, '../packages/thumbprint-react/index.js')

--- a/www/gatsby-node.js
+++ b/www/gatsby-node.js
@@ -29,11 +29,11 @@ exports.onCreateWebpackConfig = ({ actions }) => {
                 // locally because it'd require running re-compiling the code
                 // after each change.
                 '@thumbtack/thumbprint-react':
-                    process.env.NODE_ENV !== 'production'
+                    process.env.NODE_ENV === 'development'
                         ? path.resolve(__dirname, '../packages/thumbprint-react/index.js')
                         : '@thumbtack/thumbprint-react',
                 '@thumbtack/thumbprint-scss':
-                    process.env.NODE_ENV !== 'production'
+                    process.env.NODE_ENV === 'development'
                         ? path.resolve(__dirname, '../packages/thumbprint-scss/components.scss')
                         : '@thumbtack/thumbprint-scss',
             },

--- a/www/gatsby-node.js
+++ b/www/gatsby-node.js
@@ -21,6 +21,20 @@ exports.onCreateWebpackConfig = ({ actions }) => {
     actions.setWebpackConfig({
         resolve: {
             modules: [path.resolve(__dirname, 'src'), 'node_modules'],
+            alias: {
+                // Use Thumbprint React and SCSS source files when `import`'ing them in the
+                // documentation. By default, Webpack will use the value of the `main` or `module`
+                // field in the package's `package.json` file. This makes it difficult to develop
+                // locally because it'd require running re-compiling the code after each change.
+                '@thumbtack/thumbprint-react':
+                    process.env.NODE_ENV !== 'production'
+                        ? path.resolve(__dirname, '../packages/thumbprint-react/index.js')
+                        : '@thumbtack/thumbprint-react',
+                '@thumbtack/thumbprint-scss':
+                    process.env.NODE_ENV !== 'production'
+                        ? path.resolve(__dirname, '../packages/thumbprint-scss/components.scss')
+                        : '@thumbtack/thumbprint-scss',
+            },
         },
     });
 };


### PR DESCRIPTION
This updates Gatsby's webpack config to prefer the local copy of our components when developing locally.