### PR TITLE
Remove @default from React code

### DIFF
--- a/packages/thumbprint-react/CHANGELOG.md
+++ b/packages/thumbprint-react/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 -   [Patch] Use a red border in the `caution` button focus state. (#116)
 -   [Patch] Support all `autocomplete` values in `Input` component. (#113)
+-   [Patch] Remove `@default` annotation from JSDoc comments.
 
 ### Fixed
 

--- a/packages/thumbprint-react/components/Avatar/index.jsx
+++ b/packages/thumbprint-react/components/Avatar/index.jsx
@@ -102,9 +102,6 @@ EntityAvatar.defaultProps = {
     size: 'medium',
 };
 
-/**
- * @default
- */
 export default class Avatar extends React.Component {
     componentDidMount() {
         // These imports are only needed client-side and allow for lazy-loading images. They should

--- a/packages/thumbprint-react/components/Button/index.jsx
+++ b/packages/thumbprint-react/components/Button/index.jsx
@@ -89,9 +89,6 @@ TextButton.defaultProps = {
     dataTest: undefined,
 };
 
-/**
- * @default
- */
 const Button = React.forwardRef((props, ref) => (
     <Themed
         {...getCommonProps(props)}

--- a/packages/thumbprint-react/components/Input/index.jsx
+++ b/packages/thumbprint-react/components/Input/index.jsx
@@ -131,9 +131,6 @@ InputIcon.defaultProps = {
     color: 'inherit',
 };
 
-/**
- * @default
- */
 class Input extends React.Component {
     constructor(props) {
         super(props);

--- a/packages/thumbprint-react/components/Link/index.jsx
+++ b/packages/thumbprint-react/components/Link/index.jsx
@@ -23,7 +23,6 @@ const getCommonLinkProps = props => {
 
 /**
  * Anchor link that renders as text.
- * @default
  */
 const Link = React.forwardRef((props, ref) => (
     <Plain {...getCommonLinkProps(props)} theme={props.theme} iconLeft={props.iconLeft} ref={ref} />

--- a/packages/thumbprint-react/components/ModalDefault/index.jsx
+++ b/packages/thumbprint-react/components/ModalDefault/index.jsx
@@ -288,9 +288,6 @@ class ModalDefaultFooter extends React.Component {
 ModalDefaultFooter.propTypes = modalFooterPropTypes;
 ModalDefaultFooter.defaultProps = modalFooterDefaultProps;
 
-/**
- * @default
- */
 class ModalDefault extends React.Component {
     constructor(props) {
         super(props);

--- a/packages/thumbprint-react/components/ServiceCard/index.jsx
+++ b/packages/thumbprint-react/components/ServiceCard/index.jsx
@@ -50,9 +50,6 @@ function ServiceCardDescription({ iconColor, icon, children }) {
     );
 }
 
-/**
- * @default
- */
 export default function ServiceCard({ url, children }) {
     return (
         <a href={url} className={styles.root}>


### PR DESCRIPTION
It used to be used to indicate which React component in a package was the default export. We don't need this anymore since we no longer have default exports (due to the React package consolidation).