### PR TITLE
Add "centered grid" example

### DIFF
--- a/www/src/pages/atomic/index.mdx
+++ b/www/src/pages/atomic/index.mdx
@@ -389,7 +389,7 @@ Options for block, inline, and tables elements.
 
 ## Grid
 
-These classes should be used in place of `grid`. That will be deprecated.
+These classes should be used in place of the [SCSS `grid`](/components/grid/scss/). That has been deprecated.
 
 -   Columns should be divisible by 12.
 -   The immediate child of a `grid` will default to 100% width, which is common for mobile.
@@ -455,6 +455,20 @@ These classes should be used in place of `grid`. That will be deprecated.
     <div className="s_col-3 mb3 s_mb0">...content...</div>
     <div className="s_col-3 mb3 s_mb0">...content...</div>
     <div className="s_col-6">...content...</div>
+</div>
+```
+
+### Centered grid
+
+Though this design pattern is often built using grid classes, it is more easily solved by using `mw7 center tc`.
+
+```html
+<div class="mw7 center tc">
+    <div class="ba b-green">
+        “In our industry, you hear a lot of talk about the future of work. What I’ve come to believe
+        — because I see it every day — is that the entrepreneurial spirit of independent
+        professionals is the most precious resource we have as a society.”
+    </div>
 </div>
 ```
 

--- a/www/src/pages/components/grid/react/index.mdx
+++ b/www/src/pages/components/grid/react/index.mdx
@@ -68,6 +68,20 @@ import { ComponentHeader, ComponentFooter } from 'components/thumbprint-componen
 </Grid>
 ```
 
+### Centered grid
+
+Though this design pattern is often built using the Grid component, it is more easily solved by using Atomic classes: `mw7 center tc`.
+
+```html
+<div class="mw7 center tc">
+    <div class="ba b-green">
+        “In our industry, you hear a lot of talk about the future of work. What I’ve come to believe
+        — because I see it every day — is that the entrepreneurial spirit of independent
+        professionals is the most precious resource we have as a society.”
+    </div>
+</div>
+```
+
 <ComponentFooter data={props.data} />
 
 export const pageQuery = graphql`

--- a/www/src/pages/components/grid/react/index.mdx
+++ b/www/src/pages/components/grid/react/index.mdx
@@ -70,7 +70,7 @@ import { ComponentHeader, ComponentFooter } from 'components/thumbprint-componen
 
 ### Centered grid
 
-Though this design pattern is often built using the Grid component, it is more easily solved by using Atomic classes: `mw7 center tc`.
+The `Grid` component should not be used for centered single-column grids. This can be built with [Atomic classes](https://thumbprint.design/atomic/): `mw7 center tc`.
 
 ```html
 <div class="mw7 center tc">


### PR DESCRIPTION
Adds example of a "centered grid" using Atomic. 

Fixes #28 (assuming we're not building this into a component)