### PR TITLE
Document all color tokens

### DIFF
--- a/www/src/pages/tokens.jsx
+++ b/www/src/pages/tokens.jsx
@@ -34,7 +34,6 @@ const TokenRow = ({ group, groupName, language }) => (
                             key={token.id}
                             className={classNames({
                                 'bb b-gray-300': groupName === 'null' && index !== group.length - 1,
-                                dn: token.private,
                             })}
                         >
                             <td className="tl pv2" data-algolia="include">
@@ -189,7 +188,6 @@ export const pageQuery = graphql`
                         type
                         description
                         deprecated
-                        private
                         value
                         group
                     }


### PR DESCRIPTION
We previously marked some as "Private" so that they could only be used internally. @tomgenoni and I both think we should just document all of them for increased clarity.