### PR TITLE
Support close on browser back button in ModalCurtain.

### DIFF
--- a/packages/thumbprint-react/components/ModalCurtain/index.jsx
+++ b/packages/thumbprint-react/components/ModalCurtain/index.jsx
@@ -67,6 +67,18 @@ export default class ModalCurtain extends React.Component {
         this.setState({ isClient: true });
     }
 
+    componentDidUpdate(prevProps) {
+        const { stage } = this.props;
+
+        if (prevProps.stage !== stage && window && window.history) {
+            if (stage === 'entering') {
+                window.history.pushState({}, document.title);
+            } else if (stage === 'exiting') {
+                window.history.back();
+            }
+        }
+    }
+
     render() {
         const { isClient } = this.state;
         const { shouldCloseOnEscape, accessibilityLabel, onCloseClick, children } = this.props;


### PR DESCRIPTION
This is WIP to prototype what it'd be like to implement #136 in Thumbprint.

If this is behaving as I intended:

* Opening a modal then pressing the browser's back button will close the modal while remaining on the page. It won't animate. (Should it? If so, how?)
* Opening a modal then pressing the browser's back button _twice_ will take you to the previous page.
* Opening a modal, closing it by manually, and pressing the browser back button will take you to the previous page.

Things I'm still unsure about:

* Should this be in Thumbprint? It'd be our first UI component that messes with browser history.
* Should it be _only_ for full-screen modals? If so, this code should probably be in `ModalDefault` since that modal is full-screen only on small screens.
* Is `window.history.pushState` the right way to do this?
* Is browser support an issue here? If it is, will this degrade nicely or fail loudly? Need to look this up and QA this a bunch.

Known bugs:

* Browser is scrolling to the top of the page (even if close button is clicked manually). This is because `window.history.back()` runs every time the modal closes.
* When you hit back, the forward nav is still enabled and is a noop.

***
Fixes #136.

***
This can be previewed at: 
https://deploy-preview-146--thumbprint.netlify.com/components/modal-default/react/