### PR TITLE
Use subset font

### DIFF
--- a/packages/thumbprint-font-face/CHANGELOG.md
+++ b/packages/thumbprint-font-face/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
--   [Minor] Change font path to point to subsetted version of font.
+-   [Major] Change font path to point to subsetted version of font.
 
 ## 0.1.1 - 2019-03-11
 

--- a/packages/thumbprint-font-face/CHANGELOG.md
+++ b/packages/thumbprint-font-face/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+-   [Minor] Change font path to point to subsetted version of font.
+
 ## 0.1.1 - 2019-03-11
 
 ### Changed

--- a/packages/thumbprint-font-face/__snapshots__/test.js.snap
+++ b/packages/thumbprint-font-face/__snapshots__/test.js.snap
@@ -4,11 +4,11 @@ exports[`works if variable is provided 1`] = `
 "@font-face {
   font-family: 'Mark';
   font-weight: 400;
-  src: url(https://example.com/fonts/mark/mark-tt.woff2) format(\\"woff2\\"), url(https://example.com/fonts/mark/mark-tt.woff) format(\\"woff\\"); }
+  src: url(https://example.com/fonts/mark/mark-tt-subset.woff2) format(\\"woff2\\"), url(https://example.com/fonts/mark/mark-tt-subset.woff) format(\\"woff\\"); }
 
 @font-face {
   font-family: 'Mark';
   font-weight: 700;
-  src: url(https://example.com/fonts/mark/mark-tt-bold.woff2) format(\\"woff2\\"), url(https://example.com/fonts/mark/mark-tt-bold.woff) format(\\"woff\\"); }
+  src: url(https://example.com/fonts/mark/mark-tt-subset-bold.woff2) format(\\"woff2\\"), url(https://example.com/fonts/mark/mark-tt-subset-bold.woff) format(\\"woff\\"); }
 "
 `;

--- a/packages/thumbprint-font-face/_index.scss
+++ b/packages/thumbprint-font-face/_index.scss
@@ -7,15 +7,15 @@
     @font-face {
         font-family: 'Mark';
         font-weight: 400;
-        src: url(#{$thumbprint-font-url}mark/mark-tt.woff2) format('woff2'),
-            url(#{$thumbprint-font-url}mark/mark-tt.woff) format('woff');
+        src: url(#{$thumbprint-font-url}mark/mark-tt-subset.woff2) format('woff2'),
+            url(#{$thumbprint-font-url}mark/mark-tt-subset.woff) format('woff');
     }
 
     @font-face {
         font-family: 'Mark';
         font-weight: 700;
-        src: url(#{$thumbprint-font-url}mark/mark-tt-bold.woff2) format('woff2'),
-            url(#{$thumbprint-font-url}mark/mark-tt-bold.woff) format('woff');
+        src: url(#{$thumbprint-font-url}mark/mark-tt-subset-bold.woff2) format('woff2'),
+            url(#{$thumbprint-font-url}mark/mark-tt-subset-bold.woff) format('woff');
     }
 } @else {
     @error "The variable `$thumbprint-font-url` must be provided if using the `@thumbtack/thumbprint-font-face` package. Please visit our documentation for help: https://thumbprint.design/components/font-face/scss/";


### PR DESCRIPTION
This change points the URL to our subsetted fonts which have a smaller character set, and are about 40% smaller, than the originals. 