### PR TITLE
Replace use of deprecated type tokens

### DIFF
--- a/packages/thumbprint-react/CHANGELOG.md
+++ b/packages/thumbprint-react/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 -   [Patch] Set focus to `ModalCurtain` root instead of the first focusable element within modal (#156)
+-   [Patch] Replace deprecated `tp-font__text` tokens with new values. (#171)
 
 ## 0.2.4 - 2019-03-11
 

--- a/packages/thumbprint-react/components/Avatar/index.module.scss
+++ b/packages/thumbprint-react/components/Avatar/index.module.scss
@@ -13,25 +13,25 @@
 .rootSmall {
     width: $tp-avatar__size__small;
     height: $tp-avatar__size__small;
-    font-size: $tp-font__text__4__size;
+    font-size: $tp-font__body__3__size;
 }
 
 .rootMedium {
     width: $tp-avatar__size__medium;
     height: $tp-avatar__size__medium;
-    font-size: $tp-font__text__4__size;
+    font-size: $tp-font__body__3__size;
 }
 
 .rootLarge {
     width: $tp-avatar__size__large;
     height: $tp-avatar__size__large;
-    font-size: $tp-font__text__3__size;
+    font-size: $tp-font__body__2__size;
 }
 
 .rootXlarge {
     width: $tp-avatar__size__xlarge;
     height: $tp-avatar__size__xlarge;
-    font-size: $tp-font__text__1__size;
+    font-size: $tp-font__title__4__size;
 }
 
 // baseAvatar is a collection of styles common to all avatars.

--- a/packages/thumbprint-scss/CHANGELOG.md
+++ b/packages/thumbprint-scss/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+-   [Patch] Replace deprecated `tp-font__text` tokens with new values. (#171)
+
 ## 0.1.3 - 2019-03-11
 
 ### Changed

--- a/packages/thumbprint-scss/mixins/type.scss
+++ b/packages/thumbprint-scss/mixins/type.scss
@@ -162,29 +162,29 @@
 // Text sizes
 
 @mixin tp-text-1--static($important: null) {
-    font-size: $tp-font__text__1__size $important;
-    line-height: $tp-font__text__1__line-height $important;
+    font-size: $tp-font__title__4__size $important;
+    line-height: 1.6 $important;
 }
 
 @mixin tp-text-1($important: null) {
     @include tp-text-1--static($important: null);
     @include tp-respond-above($tp-breakpoint__medium) {
-        font-size: $tp-font__text__1__responsive__size $important;
-        line-height: $tp-font__text__1__responsive__line-height $important;
+        font-size: 24px $important;
+        line-height: 1.5 $important;
     }
 }
 
 @mixin tp-text-2--static($important: null) {
-    font-size: $tp-font__text__2__size $important;
-    line-height: $tp-font__text__2__line-height $important;
+    font-size: $tp-font__body__1__size $important;
+    line-height: 1.6 $important;
 }
 
 @mixin tp-text-3--static($important: null) {
-    font-size: $tp-font__text__3__size $important;
-    line-height: $tp-font__text__3__line-height $important;
+    font-size: $tp-font__body__2__size $important;
+    line-height: 1.6 $important;
 }
 
 @mixin tp-text-4--static($important: null) {
-    font-size: $tp-font__text__4__size $important;
-    line-height: $tp-font__text__4__line-height $important;
+    font-size: $tp-font__body__3__size $important;
+    line-height: 1.6 $important;
 }

--- a/packages/thumbprint-scss/scss/table.scss
+++ b/packages/thumbprint-scss/scss/table.scss
@@ -18,7 +18,7 @@
 
     th {
         font-weight: 700;
-        font-size: $tp-font__text__1__size;
+        font-size: $tp-font__title__4__size;
         color: $tp-color__black-300;
         text-align: left;
 


### PR DESCRIPTION
This is part of the work for #171.


Deprecated token id | Value | New token or value
-- | -- | --
tp-font__text__1__size | 20px | tp-font__title__4__size
tp-font__text__1__line-height | 1.6 | 1.6
tp-font__text__1__responsive__size | 24px | 24px
tp-font__text__1__responsive__line-height | 1.5 | 1.5
tp-font__text__2__size | 16px | tp-font__body__1__size
tp-font__text__2__line-height | 1.6 | 1.6
tp-font__text__3__size | 14px | tp-font__body__2__size
tp-font__text__3__line-height | 1.6 | 1.6
tp-font__text__4__size | 12px | tp-font__body__3__size
tp-font__text__4__line-height | 1.6 | 1.6

