### PR TITLE
Fix popper.js test errors

### DIFF
--- a/packages/thumbprint-react/components/Tooltip/test.jsx
+++ b/packages/thumbprint-react/components/Tooltip/test.jsx
@@ -7,6 +7,25 @@ const ESC_KEY = 27;
 
 jest.useFakeTimers();
 
+// https://github.com/thumbtack/thumbprint/issues/72
+// https://github.com/FezVrasta/popper.js/issues/478#issuecomment-341494703
+jest.mock('popper.js', () => {
+    const PopperJS = jest.requireActual('popper.js');
+
+    class Popper {
+        constructor() {
+            return {
+                destroy: () => {},
+                scheduleUpdate: () => {},
+            };
+        }
+    }
+
+    Popper.placements = PopperJS.placements;
+
+    return Popper;
+});
+
 test('renders a closed tooltip', () => {
     const wrapper = mount(
         <Tooltip text="Goose">


### PR DESCRIPTION
Fixes #72.

***
This works by telling Jest not to use the actual `popper.js` when running the test since it doesn't work in Jest. Solution is also documented here: https://github.com/FezVrasta/popper.js#how-to-use-popperjs-in-jest