### PR TITLE
Textarea/Select now have feature parity with Input

### DIFF
--- a/packages/thumbprint-react/CHANGELOG.md
+++ b/packages/thumbprint-react/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Added
+
+-   [Minor] `Select`'s `onChange` function now sends the original event as a second argument (#188)
+-   [Minor] `Select` now supports `onBlur` and `onFocus` props
+-   [Minor] `Textarea` now supports a `name` prop
+
 ## 0.3.0 - 2019-03-28
 
 ### Added

--- a/packages/thumbprint-react/components/Select/index.jsx
+++ b/packages/thumbprint-react/components/Select/index.jsx
@@ -33,6 +33,8 @@ const Select = ({
     isRequired,
     name,
     onChange,
+    onFocus,
+    onBlur,
     onClick,
     size,
     value,
@@ -59,7 +61,9 @@ const Select = ({
                 required={isRequired}
                 value={value}
                 onClick={() => onClick && onClick()}
-                onChange={e => onChange(e.target.value)}
+                onChange={e => onChange(e.target.value, e)}
+                onFocus={onFocus}
+                onBlur={onBlur}
                 data-test={dataTest}
                 name={name}
             >
@@ -119,6 +123,14 @@ Select.propTypes = {
      */
     onChange: PropTypes.func.isRequired,
     /**
+     * Fires when the select receives focus.
+     */
+    onFocus: PropTypes.func,
+    /**
+     * Fires when the select loses focus.
+     */
+    onBlur: PropTypes.func,
+    /**
      * A selector hook into the React component for use in automated testing environments.
      */
     dataTest: PropTypes.string,
@@ -137,6 +149,8 @@ Select.defaultProps = {
     isFullWidth: false,
     size: 'large',
     onClick: undefined,
+    onFocus: undefined,
+    onBlur: undefined,
     dataTest: undefined,
     name: undefined,
 };

--- a/packages/thumbprint-react/components/Select/test.jsx
+++ b/packages/thumbprint-react/components/Select/test.jsx
@@ -49,19 +49,39 @@ test('uses `value` as the selected option', () => {
     expect(wrapper).toMatchSnapshot();
 });
 
-test('calls `onChange` function and supplies new value', () => {
+test('calls `onChange` function and supplies new value and event', () => {
     const onChange = jest.fn();
 
     const wrapper = mount(<Select onChange={onChange} value="goose" />);
     const select = wrapper.find('select');
 
-    select.simulate('change', { target: { value: 'He' } });
+    const event1 = { target: { value: 'He' } };
+    select.simulate('change', event1);
     expect(onChange).toHaveBeenCalledTimes(1);
-    expect(onChange).toHaveBeenLastCalledWith('He');
+    expect(onChange).toHaveBeenLastCalledWith(event1.target.value, expect.objectContaining(event1));
 
-    select.simulate('change', { target: { value: 'Hello' } });
+    const event2 = { target: { value: 'Hello' } };
+    select.simulate('change', event2);
     expect(onChange).toHaveBeenCalledTimes(2);
-    expect(onChange).toHaveBeenLastCalledWith('Hello');
+    expect(onChange).toHaveBeenLastCalledWith(event2.target.value, expect.objectContaining(event2));
+});
+
+test('calls `onBlur` function when supplied', () => {
+    const onBlur = jest.fn();
+
+    const wrapper = mount(<Select onBlur={onBlur} onChange={jest.fn} value="goose" />);
+
+    wrapper.find('select').simulate('blur');
+    expect(onBlur).toHaveBeenCalledTimes(1);
+});
+
+test('calls `onFocus` function when supplied', () => {
+    const onFocus = jest.fn();
+
+    const wrapper = mount(<Select onFocus={onFocus} onChange={jest.fn} value="goose" />);
+
+    wrapper.find('select').simulate('focus');
+    expect(onFocus).toHaveBeenCalledTimes(1);
 });
 
 test('calls `onClick` function when clicked on', () => {

--- a/packages/thumbprint-react/components/Textarea/__snapshots__/test.jsx.snap
+++ b/packages/thumbprint-react/components/Textarea/__snapshots__/test.jsx.snap
@@ -78,6 +78,26 @@ exports[`adds \`maxLength\` attribute 1`] = `
 </Textarea>
 `;
 
+exports[`adds \`name\` HTML attribute 1`] = `
+<Textarea
+  hasError={false}
+  isDisabled={false}
+  isRequired={false}
+  name="duck"
+  onChange={[Function]}
+  value="goose"
+>
+  <textarea
+    className="root rootStateDefault"
+    disabled={false}
+    name="duck"
+    onChange={[Function]}
+    required={false}
+    value="goose"
+  />
+</Textarea>
+`;
+
 exports[`adds \`required\` attribute 1`] = `
 <Textarea
   hasError={false}

--- a/packages/thumbprint-react/components/Textarea/index.jsx
+++ b/packages/thumbprint-react/components/Textarea/index.jsx
@@ -27,6 +27,7 @@ const Textarea = ({
     onFocus,
     placeholder,
     value,
+    name,
 }) => {
     const uiState = getUIState({ hasError, isDisabled });
 
@@ -48,6 +49,7 @@ const Textarea = ({
             onFocus={onFocus}
             onBlur={onBlur}
             data-test={dataTest}
+            name={name}
         />
     );
 };
@@ -74,6 +76,10 @@ Textarea.propTypes = {
      * Text that appears within the textarea when there is no `value`.
      */
     placeholder: PropTypes.string,
+    /**
+     * Adds `name` HTML attribute to element, indicating the property name associated with the selected value.
+     */
+    name: PropTypes.string,
     /**
      * The current value of the textarea.
      */
@@ -117,6 +123,7 @@ Textarea.defaultProps = {
     onFocus: undefined,
     onBlur: undefined,
     dataTest: undefined,
+    name: undefined,
 };
 
 export default Textarea;

--- a/packages/thumbprint-react/components/Textarea/test.jsx
+++ b/packages/thumbprint-react/components/Textarea/test.jsx
@@ -38,6 +38,12 @@ test('adds `maxLength` attribute', () => {
     expect(wrapper).toMatchSnapshot();
 });
 
+test('adds `name` HTML attribute', () => {
+    const wrapperA = mount(<Textarea name="duck" onChange={noop} value="goose" />);
+    expect(wrapperA.find('textarea').prop('name')).toEqual('duck');
+    expect(wrapperA).toMatchSnapshot();
+});
+
 test('renders `value` as the `value` attribute', () => {
     const wrapper = render(<Textarea value="Goose" onChange={jest.fn} />);
     expect(wrapper.text()).toBe('Goose');


### PR DESCRIPTION
### Change Summary

* Added support for `onFocus` and `onBlur` props on `Select`
* Modified `onChange` signature for `Select` from `value => { ...}` to `(value, event) => { ... }`
* Added support for `name` prop on `Textarea`

Fixes #188

~~__Question__: How do I modify the CHANGELOG.md properly to explain these changes?~~
