### PR TITLE
Move prettier format check to bash script

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         "test": "yarn run bootstrap && yarn run test:lint && yarn run test:jest && yarn run test:prettier",
         "test:jest": "TZ=America/Los_Angeles jest",
         "test:jest:watch": "yarn run bootstrap && yarn test:jest --watch",
-        "test:prettier": "prettier \"**/*.{js,jsx,css,scss,json,md,mdx,html}\" --list-different || (c=$?; echo \"\n⚠️  Some files in this branch have not been formatted with Prettier. Please run 'yarn run format' to format them.\n\"; (exit $c))",
+        "test:prettier": "./scripts/test-prettier.sh",
         "test:lint": "yarn test:lint:md && yarn test:lint:css && yarn test:lint:js",
         "test:lint:md": "remark \"packages/*/CHANGELOG.md\" --frail --quiet",
         "test:lint:css": "stylelint --ignore-pattern **/*.module.scss **/*.scss",

--- a/scripts/test-prettier.sh
+++ b/scripts/test-prettier.sh
@@ -1,6 +1,4 @@
 #!/bin/bash
 yarn prettier "**/*.{js,jsx,css,scss,json,md,mdx,html}" --list-different || (c=$?; echo "
-
 ⚠️  Some files in this branch have not been formatted with Prettier. Please run 'yarn run format' to format them.
-
 "; (exit $c))

--- a/scripts/test-prettier.sh
+++ b/scripts/test-prettier.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+yarn prettier "**/*.{js,jsx,css,scss,json,md,mdx,html}" --list-different || (c=$?; echo "
+
+⚠️  Some files in this branch have not been formatted with Prettier. Please run 'yarn run format' to format them.
+
+"; (exit $c))


### PR DESCRIPTION
This fixes a common pain point with developing in Thumbprint. In the current setup, the error message would appear grayed out because it is the source of the NPM script. This confused developers because it was not obvious. Moving this to a bash script allows us to hide the message unless there is an error.

Here is how it looks with this PR:

![image](https://user-images.githubusercontent.com/916038/55444206-56a41900-556a-11e9-8df1-e7bb9b38f42a.png)
