### PR TITLE
Replace tpSpacerUnit with tpSpace3

### DIFF
--- a/packages/thumbprint-react/CHANGELOG.md
+++ b/packages/thumbprint-react/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 -   [Patch] Fix `ButtonRow` so that it displays the primary call to action on top when the button row is stacked.
+-   [Patch] Replace `tpSpacerUnit` with `tpSpace3` to remove dependencies on the deprecated spacer unit.
 
 ## 0.5.1 - 2019-04-02
 

--- a/packages/thumbprint-react/CHANGELOG.md
+++ b/packages/thumbprint-react/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+### Changed
+
 -   [Patch] Fix `ButtonRow` so that it displays the primary call to action on top when the button row is stacked.
 -   [Patch] Replace `tpSpacerUnit` with `tpSpace3` to remove dependencies on the deprecated spacer unit.
 

--- a/packages/thumbprint-react/components/Tooltip/index.jsx
+++ b/packages/thumbprint-react/components/Tooltip/index.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { tpSpacerUnit } from '@thumbtack/thumbprint-tokens';
+import { tpSpace3 } from '@thumbtack/thumbprint-tokens';
 import assign from 'lodash/assign';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
@@ -47,7 +47,7 @@ const PositionedTooltip = ({
     <Popper
         placement={position}
         modifiers={{
-            offset: { offset: `0, ${tpSpacerUnit * 2}px` },
+            offset: { offset: `0, ${tpSpace3}` },
             preventOverflow: { boundariesElement: 'window' },
         }}
         positionFixed={false}


### PR DESCRIPTION
Swapping in a space token for the deprecated `tpSpacerUnit`. This is only usage in Thumbprint of this deprecated token.