### PR TITLE
Update documentation for styling links (#211)

### DIFF
--- a/www/src/pages/components/link/react/index.mdx
+++ b/www/src/pages/components/link/react/index.mdx
@@ -81,9 +81,9 @@ Links also inherit the font weight of their container.
 ```jsx
 <React.Fragment>
     Learn more about{' '}
-    <strong>
+    <span className="b">
         <Link to="https://www.facebook.com/Thumbtack/">Thumbtack on Facebook</Link>
-    </strong>
+    </span>
     .
 </React.Fragment>
 ```


### PR DESCRIPTION
The usage of strong tag as an example to style the link bold
may imply that we should use the strong tag for styling
purposes. The strong tag should be used to add semantics
to content.