### PR TITLE
Improve cache that determines when to build packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "eslint-plugin-react": "^7.11.1",
         "eslint-plugin-react-hooks": "^1.6.0",
         "execa": "^0.10.0",
-        "folder-hash": "^2.1.1",
+        "folder-hash": "^3.0.0",
         "fs-extra": "^7.0.0",
         "husky": "^1.1.2",
         "identity-obj-proxy": "^3.0.0",

--- a/scripts/should-build-package.js
+++ b/scripts/should-build-package.js
@@ -12,13 +12,17 @@ process.on('unhandledRejection', error => {
 });
 
 const getHash = async dir => {
-    const { hash } = await hashElement(dir, {
+    const yarnLockLocation = path.join(dir, '../../yarn.lock');
+
+    const { hash: hashPackageFolder } = await hashElement(dir, {
         folders: {
             exclude: ['.cache', 'dist'],
         },
     });
 
-    return hash;
+    const { hash: hashYarnLock } = await hashElement(yarnLockLocation);
+
+    return hashPackageFolder + hashYarnLock;
 };
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -6632,12 +6632,12 @@ focus-visible@^4.1.5:
   resolved "https://registry.yarnpkg.com/focus-visible/-/focus-visible-4.1.5.tgz#50b44e2e84c24b831ceca3cce84d57c2b311c855"
   integrity sha512-yo/njtk/BB4Z2euzaZe3CZrg4u5s5uEi7ZwbHBJS2quHx51N0mmcx9nTIiImUGlgy+vf26d0CcQluahBBBL/Fw==
 
-folder-hash@^2.1.1:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/folder-hash/-/folder-hash-2.1.2.tgz#7109f9cd0cbca271936d1b5544b156d6571e6cfd"
-  integrity sha512-PmMwEZyNN96EMshf7sek4OIB7ADNsHOJ7VIw7pO0PBI0BNfEsi7U8U56TBjjqqwQ0WuBv8se0HEfmbw5b/Rk+w==
+folder-hash@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/folder-hash/-/folder-hash-3.0.0.tgz#ba9489e74044f63a943d74a3be5e10eb0d03b0ab"
+  integrity sha512-wyAJJO+h09XC7ZUM47RZIefAZlpTmdxidp98aoSd/BapfjFIx3Z7bJOO3cPy/WNep5WtX7vjBJhdTPKhFfRKMQ==
   dependencies:
-    debug "^3.1.0"
+    debug "^4.1.1"
     graceful-fs "~4.1.11"
     minimatch "~3.0.4"
 


### PR DESCRIPTION
We have a basic cache that determines when to build packages. The cache previously worked by creating a hash of the package folder. It would invalidate only when the package folder changed. 

That implementation caused bugs because changes to global dependencies (such as `browserslist`) would not invalidate the cache to re-build. This led to mismatches between CI and local machines since CI doesn't use any cache.

Ultimately, this fixes #212, an issue where a version bump of `browserslist` was failing locally but passing in CI. This commit fixes it because changes to `yarn.lock` will now invalidate the cache.

***
I considered simply removing the cache, but it would add 15+ seconds to each `yarn start` or `yarn test`. Since we run those commands often while developing locally, I think that this solution is better.