### PR TITLE
Support `width` in the `Image` component.

### DIFF
--- a/packages/thumbprint-react/CHANGELOG.md
+++ b/packages/thumbprint-react/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+-   [Patch] Support `width` classes and inline styles in the `Image` component. (#238)
+
 ## 0.7.0 - 2019-05-09
 
 ### Added

--- a/packages/thumbprint-react/components/Image/index.jsx
+++ b/packages/thumbprint-react/components/Image/index.jsx
@@ -22,7 +22,6 @@ const Image = forwardRef((props, outerRef) => {
         containerAspectRatio,
         objectFit,
         objectPosition,
-        width,
         alt,
         ...rest
     } = props;
@@ -82,6 +81,8 @@ const Image = forwardRef((props, outerRef) => {
         },
     };
 
+    const aspectRatioBoxProps = {};
+
     if (shouldObjectFit) {
         pictureProps.style = {
             ...pictureProps.style,
@@ -108,9 +109,11 @@ const Image = forwardRef((props, outerRef) => {
 
         containerProps.style = {
             ...containerProps.style,
-            paddingTop: `${(h / w) * 100}%`,
-            overflow: 'hidden',
             position: 'relative',
+        };
+
+        aspectRatioBoxProps.style = {
+            paddingTop: `${(h / w) * 100}%`,
         };
 
         pictureProps.style = {
@@ -157,6 +160,9 @@ const Image = forwardRef((props, outerRef) => {
                 }
             }}
         >
+            {/* This `div` holds the space set by `containerAspectRatio`. */}
+            {Object.keys(aspectRatioBoxProps).length > 0 && <div {...aspectRatioBoxProps} />}
+
             {picture}
         </div>
     );

--- a/www/src/pages/components/image/react/index.mdx
+++ b/www/src/pages/components/image/react/index.mdx
@@ -18,6 +18,26 @@ import { ComponentHeader, ComponentFooter } from 'components/thumbprint-componen
 />
 ```
 
+### Two side-by-side images
+
+```jsx
+<div className="flex">
+    <Image
+        src="https://d1vg1gqh4nkuns.cloudfront.net/i/302056478120263859/width/1024.jpeg"
+        alt="Photo of a sprinker"
+        containerAspectRatio={768 / 400}
+        style={{ width: '50%' }}
+        className="mr1"
+    />
+    <Image
+        src="https://d1vg1gqh4nkuns.cloudfront.net/i/327896627728072894/width/1024.jpeg"
+        alt="Photo of grass with concrete steps"
+        containerAspectRatio={768 / 400}
+        className="ml1 w-50"
+    />
+</div>
+```
+
 <ComponentFooter data={props.data} />
 
 export const pageQuery = graphql`


### PR DESCRIPTION
Fixes #238.

Instead of adding a `width` prop, we can allow consumers to pass in a width through `className` or `style`. This works because the padding aspect ratio CSS is in a new child element, not the parent element that receives the width.

I've also added an example of two side-by-side images.