### PR TITLE
Remove references to deprecated tokens.

### DIFF
--- a/packages/thumbprint-react/CHANGELOG.md
+++ b/packages/thumbprint-react/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+-   [Patch] Remove references to deprecated tokens.
+
 ## 0.7.1 - 2019-05-15
 
 ### Changed

--- a/packages/thumbprint-react/components/Avatar/index.module.scss
+++ b/packages/thumbprint-react/components/Avatar/index.module.scss
@@ -5,32 +5,32 @@
 }
 
 .rootXsmall {
-    width: $tp-avatar__size__xsmall;
-    height: $tp-avatar__size__xsmall;
+    width: 20px;
+    height: 20px;
     font-size: 8px;
 }
 
 .rootSmall {
-    width: $tp-avatar__size__small;
-    height: $tp-avatar__size__small;
+    width: 32px;
+    height: 32px;
     font-size: $tp-font__body__3__size;
 }
 
 .rootMedium {
-    width: $tp-avatar__size__medium;
-    height: $tp-avatar__size__medium;
+    width: 48px;
+    height: 48px;
     font-size: $tp-font__body__3__size;
 }
 
 .rootLarge {
-    width: $tp-avatar__size__large;
-    height: $tp-avatar__size__large;
+    width: 72px;
+    height: 72px;
     font-size: $tp-font__body__2__size;
 }
 
 .rootXlarge {
-    width: $tp-avatar__size__xlarge;
-    height: $tp-avatar__size__xlarge;
+    width: 124px;
+    height: 124px;
     font-size: $tp-font__title__4__size;
 }
 

--- a/packages/thumbprint-react/components/ModalStandard/index.module.scss
+++ b/packages/thumbprint-react/components/ModalStandard/index.module.scss
@@ -10,7 +10,7 @@ $close-button-height: 48px;
 }
 
 .contentsBrand {
-    background-color: $tp-color__ui__brand;
+    background-color: #f27802;
 }
 
 .closeButton {

--- a/packages/thumbprint-scss/CHANGELOG.md
+++ b/packages/thumbprint-scss/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+-   [Patch] Remove references to deprecated tokens.
+
 ## 1.0.1 - 2019-05-15
 
 ### Changed

--- a/packages/thumbprint-scss/__snapshots__/test.js.snap
+++ b/packages/thumbprint-scss/__snapshots__/test.js.snap
@@ -1782,73 +1782,73 @@ _:-ms-fullscreen {
 .tp-heading-1 {
   font-size: 32px;
   line-height: 1.3;
-  font-weight: 500;
+  font-weight: 400;
 }
 @media (min-width: 701px) {
   .tp-heading-1 {
     font-size: 48px;
     line-height: 1.1;
-    font-weight: 500;
+    font-weight: 400;
   }
 }
 .tp-heading-2 {
   font-size: 30px;
   line-height: 1.3;
-  font-weight: 500;
+  font-weight: 400;
 }
 @media (min-width: 701px) {
   .tp-heading-2 {
     font-size: 40px;
     line-height: 1.2;
-    font-weight: 500;
+    font-weight: 400;
   }
 }
 .tp-heading-3 {
   font-size: 24px;
   line-height: 1.4;
-  font-weight: 500;
+  font-weight: 400;
 }
 @media (min-width: 701px) {
   .tp-heading-3 {
     font-size: 32px;
     line-height: 1.3;
-    font-weight: 500;
+    font-weight: 400;
   }
 }
 .tp-heading-4 {
   font-size: 20px;
   line-height: 1.4;
-  font-weight: 500;
+  font-weight: 400;
 }
 @media (min-width: 701px) {
   .tp-heading-4 {
     font-size: 24px;
     line-height: 1.4;
-    font-weight: 500;
+    font-weight: 400;
   }
 }
 .tp-heading-5 {
   font-size: 16px;
   line-height: 1.6;
-  font-weight: 500;
+  font-weight: 400;
 }
 @media (min-width: 701px) {
   .tp-heading-5 {
     font-size: 20px;
     line-height: 1.5;
-    font-weight: 500;
+    font-weight: 400;
   }
 }
 .tp-heading-6 {
   font-size: 14px;
   line-height: 1.6;
-  font-weight: 500;
+  font-weight: 400;
 }
 @media (min-width: 701px) {
   .tp-heading-6 {
     font-size: 16px;
     line-height: 1.6;
-    font-weight: 500;
+    font-weight: 400;
   }
 }
 .tp-text-1,

--- a/packages/thumbprint-scss/mixins/avatar.scss
+++ b/packages/thumbprint-scss/mixins/avatar.scss
@@ -1,13 +1,13 @@
 // Mixins
 
 @mixin tp-avatar--xsmall($important: null) {
-    width: $tp-avatar__size__xsmall $important;
-    height: $tp-avatar__size__xsmall $important;
+    width: 20px $important;
+    height: 20px $important;
 }
 
 @mixin tp-avatar--small($important: null) {
-    width: $tp-avatar__size__small $important;
-    height: $tp-avatar__size__small $important;
+    width: 32px $important;
+    height: 32px $important;
 
     .tp-avatar__badge {
         font-size: 10px $important;
@@ -19,8 +19,8 @@
 }
 
 @mixin tp-avatar--medium($important: null) {
-    width: $tp-avatar__size__medium $important;
-    height: $tp-avatar__size__medium $important;
+    width: 48px $important;
+    height: 48px $important;
 
     .tp-avatar__badge {
         font-size: 10px $important;
@@ -32,8 +32,8 @@
 }
 
 @mixin tp-avatar--large($important: null) {
-    width: $tp-avatar__size__large $important;
-    height: $tp-avatar__size__large $important;
+    width: 72px $important;
+    height: 72px $important;
 
     .tp-avatar__badge {
         font-size: 12px $important;
@@ -44,8 +44,8 @@
 }
 
 @mixin tp-avatar--xlarge($important: null) {
-    width: $tp-avatar__size__xlarge $important;
-    height: $tp-avatar__size__xlarge $important;
+    width: 124px $important;
+    height: 124px $important;
 
     .tp-avatar__badge {
         font-size: 15px $important;

--- a/packages/thumbprint-scss/mixins/type.scss
+++ b/packages/thumbprint-scss/mixins/type.scss
@@ -90,72 +90,72 @@
 @mixin tp-heading-1($important: null) {
     font-size: 32px $important;
     line-height: 1.3 $important;
-    font-weight: 500 $important;
+    font-weight: $tp-font__weight__normal $important;
 
     @include tp-respond-above($tp-breakpoint__medium) {
         font-size: 48px $important;
         line-height: 1.1 $important;
-        font-weight: 500 $important;
+        font-weight: $tp-font__weight__normal $important;
     }
 }
 
 @mixin tp-heading-2($important: null) {
     font-size: 30px $important;
     line-height: 1.3 $important;
-    font-weight: 500 $important;
+    font-weight: $tp-font__weight__normal $important;
 
     @include tp-respond-above($tp-breakpoint__medium) {
         font-size: 40px $important;
         line-height: 1.2 $important;
-        font-weight: 500 $important;
+        font-weight: $tp-font__weight__normal $important;
     }
 }
 
 @mixin tp-heading-3($important: null) {
     font-size: 24px $important;
     line-height: 1.4 $important;
-    font-weight: 500 $important;
+    font-weight: $tp-font__weight__normal $important;
 
     @include tp-respond-above($tp-breakpoint__medium) {
         font-size: 32px $important;
         line-height: 1.3 $important;
-        font-weight: 500 $important;
+        font-weight: $tp-font__weight__normal $important;
     }
 }
 
 @mixin tp-heading-4($important: null) {
     font-size: 20px $important;
     line-height: 1.4 $important;
-    font-weight: 500 $important;
+    font-weight: $tp-font__weight__normal $important;
 
     @include tp-respond-above($tp-breakpoint__medium) {
         font-size: 24px $important;
         line-height: 1.4 $important;
-        font-weight: 500 $important;
+        font-weight: $tp-font__weight__normal $important;
     }
 }
 
 @mixin tp-heading-5($important: null) {
     font-size: 16px $important;
     line-height: 1.6 $important;
-    font-weight: 500 $important;
+    font-weight: $tp-font__weight__normal $important;
 
     @include tp-respond-above($tp-breakpoint__medium) {
         font-size: 20px $important;
         line-height: 1.5 $important;
-        font-weight: 500 $important;
+        font-weight: $tp-font__weight__normal $important;
     }
 }
 
 @mixin tp-heading-6($important: null) {
     font-size: 14px $important;
     line-height: 1.6 $important;
-    font-weight: 500 $important;
+    font-weight: $tp-font__weight__normal $important;
 
     @include tp-respond-above($tp-breakpoint__medium) {
         font-size: 16px $important;
         line-height: 1.6 $important;
-        font-weight: 500 $important;
+        font-weight: $tp-font__weight__normal $important;
     }
 }
 

--- a/packages/thumbprint-scss/mixins/type.scss
+++ b/packages/thumbprint-scss/mixins/type.scss
@@ -88,74 +88,74 @@
 // DEPRECATED
 
 @mixin tp-heading-1($important: null) {
-    font-size: $tp-font__heading__1__size $important;
-    line-height: $tp-font__heading__1__line-height $important;
-    font-weight: $tp-font__heading__1__weight $important;
+    font-size: 32px $important;
+    line-height: 1.3 $important;
+    font-weight: 500 $important;
 
     @include tp-respond-above($tp-breakpoint__medium) {
-        font-size: $tp-font__heading__1__responsive__size $important;
-        line-height: $tp-font__heading__1__responsive__line-height $important;
-        font-weight: $tp-font__heading__1__responsive__weight $important;
+        font-size: 48px $important;
+        line-height: 1.1 $important;
+        font-weight: 500 $important;
     }
 }
 
 @mixin tp-heading-2($important: null) {
-    font-size: $tp-font__heading__2__size $important;
-    line-height: $tp-font__heading__2__line-height $important;
-    font-weight: $tp-font__heading__2__weight $important;
+    font-size: 30px $important;
+    line-height: 1.3 $important;
+    font-weight: 500 $important;
 
     @include tp-respond-above($tp-breakpoint__medium) {
-        font-size: $tp-font__heading__2__responsive__size $important;
-        line-height: $tp-font__heading__2__responsive__line-height $important;
-        font-weight: $tp-font__heading__2__responsive__weight $important;
+        font-size: 40px $important;
+        line-height: 1.2 $important;
+        font-weight: 500 $important;
     }
 }
 
 @mixin tp-heading-3($important: null) {
-    font-size: $tp-font__heading__3__size $important;
-    line-height: $tp-font__heading__3__line-height $important;
-    font-weight: $tp-font__heading__3__weight $important;
+    font-size: 24px $important;
+    line-height: 1.4 $important;
+    font-weight: 500 $important;
 
     @include tp-respond-above($tp-breakpoint__medium) {
-        font-size: $tp-font__heading__3__responsive__size $important;
-        line-height: $tp-font__heading__3__responsive__line-height $important;
-        font-weight: $tp-font__heading__3__responsive__weight $important;
+        font-size: 32px $important;
+        line-height: 1.3 $important;
+        font-weight: 500 $important;
     }
 }
 
 @mixin tp-heading-4($important: null) {
-    font-size: $tp-font__heading__4__size $important;
-    line-height: $tp-font__heading__4__line-height $important;
-    font-weight: $tp-font__heading__4__weight $important;
+    font-size: 20px $important;
+    line-height: 1.4 $important;
+    font-weight: 500 $important;
 
     @include tp-respond-above($tp-breakpoint__medium) {
-        font-size: $tp-font__heading__4__responsive__size $important;
-        line-height: $tp-font__heading__4__responsive__line-height $important;
-        font-weight: $tp-font__heading__4__responsive__weight $important;
+        font-size: 24px $important;
+        line-height: 1.4 $important;
+        font-weight: 500 $important;
     }
 }
 
 @mixin tp-heading-5($important: null) {
-    font-size: $tp-font__heading__5__size $important;
-    line-height: $tp-font__heading__5__line-height $important;
-    font-weight: $tp-font__heading__5__weight $important;
+    font-size: 16px $important;
+    line-height: 1.6 $important;
+    font-weight: 500 $important;
 
     @include tp-respond-above($tp-breakpoint__medium) {
-        font-size: $tp-font__heading__5__responsive__size $important;
-        line-height: $tp-font__heading__5__responsive__line-height $important;
-        font-weight: $tp-font__heading__5__responsive__weight $important;
+        font-size: 20px $important;
+        line-height: 1.5 $important;
+        font-weight: 500 $important;
     }
 }
 
 @mixin tp-heading-6($important: null) {
-    font-size: $tp-font__heading__6__size $important;
-    line-height: $tp-font__heading__6__line-height $important;
-    font-weight: $tp-font__heading__6__weight $important;
+    font-size: 14px $important;
+    line-height: 1.6 $important;
+    font-weight: 500 $important;
 
     @include tp-respond-above($tp-breakpoint__medium) {
-        font-size: $tp-font__heading__6__responsive__size $important;
-        line-height: $tp-font__heading__6__responsive__line-height $important;
-        font-weight: $tp-font__heading__6__responsive__weight $important;
+        font-size: 16px $important;
+        line-height: 1.6 $important;
+        font-weight: 500 $important;
     }
 }
 

--- a/packages/thumbprint-scss/mixins/wrap.scss
+++ b/packages/thumbprint-scss/mixins/wrap.scss
@@ -30,17 +30,17 @@
     padding-right: $tp-space__3;
 
     @include tp-respond-above($tp-breakpoint__small) {
-        max-width: $tp-wrap-snap__small;
+        max-width: 449px;
         padding-left: 0; // Padding only applies to small size and below.
         padding-right: 0; // Padding only applies to small size and below.
     }
 
     @include tp-respond-above($tp-breakpoint__medium) {
-        max-width: $tp-wrap-snap__medium;
+        max-width: 668px;
     }
 
     @include tp-respond-above($tp-breakpoint__large) {
-        max-width: $tp-wrap-snap__large;
+        max-width: 946px;
     }
 }
 


### PR DESCRIPTION
Snapshots didn't change which means that the SCSS ones are a 1:1 mapping.