### PR TITLE
Remove the category name from Token IDs

### DIFF
--- a/packages/thumbprint-tokens/CHANGELOG.md
+++ b/packages/thumbprint-tokens/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 -   [Major] Rename [a handful of SCSS and JavaScipt tokens](https://github.com/thumbtack/thumbprint/pull/242).
+-   [Patch] Change the internals of how tokens are stored and generated. This does not affect the outputted code.
 
 ## 7.0.0 - 2019-05-17
 

--- a/packages/thumbprint-tokens/README.md
+++ b/packages/thumbprint-tokens/README.md
@@ -16,14 +16,14 @@ All tokens live within a `tokens/*.json` file. Token files follow the following 
     "description": "These are the colors we use at Thumbtack.",
     "tokens": [
         {
-            "id": "color__blue",
+            "id": "blue",
             "value": {
                 "web": "#009fd9"
             },
             "type": "color"
         },
         {
-            "id": "color__celebrate",
+            "id": "celebrate",
             "value": {
                 "web": "#fbe002"
             },

--- a/packages/thumbprint-tokens/src/helpers/javascript-cjs.js
+++ b/packages/thumbprint-tokens/src/helpers/javascript-cjs.js
@@ -1,14 +1,17 @@
 const { camelCase, isNumber } = require('lodash');
 
-module.exports = {
-    formatValue: ({ value }) => {
-        const { web: webValue } = value;
+module.exports = [
+    {
+        name: 'formatValue',
+        value: ({ value }) => {
+            const { web: webValue } = value;
 
-        if (isNumber(webValue)) {
-            return webValue;
-        }
+            if (isNumber(webValue)) {
+                return webValue;
+            }
 
-        return `"${webValue}"`;
+            return `"${webValue}"`;
+        },
     },
-    formatId: ({ id }) => camelCase(`tp-${id}`),
-};
+    { name: 'formatId', value: (section, token) => camelCase(`tp-${section.name}-${token.id}`) },
+];

--- a/packages/thumbprint-tokens/src/helpers/javascript-es.js
+++ b/packages/thumbprint-tokens/src/helpers/javascript-es.js
@@ -1,14 +1,17 @@
 const { camelCase, isNumber } = require('lodash');
 
-module.exports = {
-    formatValue: ({ value }) => {
-        const { web: webValue } = value;
+module.exports = [
+    {
+        name: 'formatValue',
+        value: ({ value }) => {
+            const { web: webValue } = value;
 
-        if (isNumber(webValue)) {
-            return webValue;
-        }
+            if (isNumber(webValue)) {
+                return webValue;
+            }
 
-        return `"${webValue}"`;
+            return `"${webValue}"`;
+        },
     },
-    formatId: ({ id }) => camelCase(`tp-${id}`),
-};
+    { name: 'formatId', value: (section, token) => camelCase(`tp-${section.name}-${token.id}`) },
+];

--- a/packages/thumbprint-tokens/src/helpers/scss.js
+++ b/packages/thumbprint-tokens/src/helpers/scss.js
@@ -1,4 +1,10 @@
-module.exports = {
-    formatId: ({ id }) => `$tp-${id}`,
-    formatValue: ({ value }) => value.web,
-};
+module.exports = [
+    {
+        name: 'formatId',
+        value: (section, token) => {
+            const sectionName = section.name.replace(/\s+/g, '-').toLowerCase();
+            return `$tp-${sectionName}__${token.id}`;
+        },
+    },
+    { name: 'formatValue', value: ({ value }) => value.web },
+];

--- a/packages/thumbprint-tokens/src/templates/javascript-cjs.handlebars
+++ b/packages/thumbprint-tokens/src/templates/javascript-cjs.handlebars
@@ -1,11 +1,13 @@
-{{#each this}}
-{{#if value.web}}
-{{#if description}}
-// {{description}}
+{{#each this as |section|}}
+{{#each section.tokens as |token|}}
+{{#if token.value.web}}
+{{#if token.description}}
+// {{token.description}}
 {{/if}}
-{{#if deprecated}}
+{{#if token.deprecated}}
 // @deprecated
 {{/if}}
-exports.{{formatId this}} = {{{formatValue this}}};
+exports.{{formatId section token}} = {{{formatValue token}}};
 {{/if}}
+{{/each}}
 {{/each}}

--- a/packages/thumbprint-tokens/src/templates/javascript-es.handlebars
+++ b/packages/thumbprint-tokens/src/templates/javascript-es.handlebars
@@ -1,11 +1,13 @@
-{{#each this}}
-{{#if value.web}}
-{{#if description}}
-// {{description}}
+{{#each this as |section|}}
+{{#each section.tokens as |token|}}
+{{#if token.value.web}}
+{{#if token.description}}
+// {{token.description}}
 {{/if}}
-{{#if deprecated}}
+{{#if token.deprecated}}
 // @deprecated
 {{/if}}
-export var {{formatId this}} = {{{formatValue this}}};
+export var {{formatId section token}} = {{{formatValue token}}};
 {{/if}}
+{{/each}}
 {{/each}}

--- a/packages/thumbprint-tokens/src/templates/scss.handlebars
+++ b/packages/thumbprint-tokens/src/templates/scss.handlebars
@@ -1,11 +1,13 @@
-{{#each this}}
-{{#if value.web}}
-{{#if description}}
-// {{description}}
+{{#each this as |section|}}
+{{#each section.tokens as |token|}}
+{{#if token.value.web}}
+{{#if token.description}}
+// {{token.description}}
 {{/if}}
-{{#if deprecated}}
+{{#if token.deprecated}}
 // @deprecated
 {{/if}}
-{{formatId this}}: {{{formatValue this}}};
+{{formatId section token}}: {{{formatValue this}}};
 {{/if}}
+{{/each}}
 {{/each}}

--- a/packages/thumbprint-tokens/src/tokens/border-radius.json
+++ b/packages/thumbprint-tokens/src/tokens/border-radius.json
@@ -2,19 +2,19 @@
     "name": "Border Radius",
     "tokens": [
         {
-            "id": "border-radius__base",
+            "id": "base",
             "value": { "web": "4px" }
         },
         {
-            "id": "border-radius__big",
+            "id": "big",
             "value": { "web": "6px" }
         },
         {
-            "id": "border-radius__full",
+            "id": "full",
             "value": { "web": "50%" }
         },
         {
-            "id": "border-radius__sides",
+            "id": "sides",
             "value": { "web": "9999px" }
         }
     ]

--- a/packages/thumbprint-tokens/src/tokens/breakpoint.json
+++ b/packages/thumbprint-tokens/src/tokens/breakpoint.json
@@ -2,43 +2,43 @@
     "name": "Breakpoint",
     "tokens": [
         {
-            "id": "breakpoint__large",
+            "id": "large",
             "value": { "web": "1025px" }
         },
         {
-            "id": "breakpoint__large__value",
+            "id": "large__value",
             "value": { "web": 1025 }
         },
         {
-            "id": "breakpoint__medium",
+            "id": "medium",
             "value": { "web": "700px" }
         },
         {
-            "id": "breakpoint__medium__value",
+            "id": "medium__value",
             "value": { "web": 700 }
         },
         {
-            "id": "breakpoint__small",
+            "id": "small",
             "value": { "web": "481px" }
         },
         {
-            "id": "breakpoint__small__value",
+            "id": "small__value",
             "value": { "web": 481 }
         },
         {
-            "id": "breakpoint__split-view__medium",
+            "id": "split-view__medium",
             "value": { "web": "1060px" }
         },
         {
-            "id": "breakpoint__split-view__medium__value",
+            "id": "split-view__medium__value",
             "value": { "web": 1060 }
         },
         {
-            "id": "breakpoint__split-view__small",
+            "id": "split-view__small",
             "value": { "web": "769px" }
         },
         {
-            "id": "breakpoint__split-view__small__value",
+            "id": "split-view__small__value",
             "value": { "web": 769 }
         }
     ]

--- a/packages/thumbprint-tokens/src/tokens/color.json
+++ b/packages/thumbprint-tokens/src/tokens/color.json
@@ -3,212 +3,212 @@
     "description": "These are the colors we use at Thumbtack.",
     "tokens": [
         {
-            "id": "color__blue-100",
+            "id": "blue-100",
             "value": { "web": "#eaf6fa" },
             "type": "color"
         },
         {
-            "id": "color__blue-200",
+            "id": "blue-200",
             "value": { "web": "#b3ebff" },
             "type": "color"
         },
         {
-            "id": "color__blue-300",
+            "id": "blue-300",
             "value": { "web": "#79d2f2" },
             "type": "color"
         },
         {
-            "id": "color__blue",
+            "id": "blue",
             "value": { "web": "#009fd9" },
             "type": "color"
         },
         {
-            "id": "color__blue-500",
+            "id": "blue-500",
             "value": { "web": "#007fad" },
             "type": "color"
         },
         {
-            "id": "color__blue-600",
+            "id": "blue-600",
             "value": { "web": "#005a7a" },
             "type": "color"
         },
         {
-            "id": "color__indigo-100",
+            "id": "indigo-100",
             "value": { "web": "#e8f1fd" },
             "type": "color"
         },
         {
-            "id": "color__indigo-200",
+            "id": "indigo-200",
             "value": { "web": "#cce1ff" },
             "type": "color"
         },
         {
-            "id": "color__indigo-300",
+            "id": "indigo-300",
             "value": { "web": "#96c2ff" },
             "type": "color"
         },
         {
-            "id": "color__indigo",
+            "id": "indigo",
             "value": { "web": "#5968e2" },
             "type": "color"
         },
         {
-            "id": "color__indigo-500",
+            "id": "indigo-500",
             "value": { "web": "#4f54b3" },
             "type": "color"
         },
         {
-            "id": "color__indigo-600",
+            "id": "indigo-600",
             "value": { "web": "#383c80" },
             "type": "color"
         },
         {
-            "id": "color__purple-100",
+            "id": "purple-100",
             "value": { "web": "#f5efff" },
             "type": "color"
         },
         {
-            "id": "color__purple-200",
+            "id": "purple-200",
             "value": { "web": "#dfccff" },
             "type": "color"
         },
         {
-            "id": "color__purple-300",
+            "id": "purple-300",
             "value": { "web": "#d3baff" },
             "type": "color"
         },
         {
-            "id": "color__purple",
+            "id": "purple",
             "value": { "web": "#a97ff0" },
             "type": "color"
         },
         {
-            "id": "color__purple-500",
+            "id": "purple-500",
             "value": { "web": "#8a5ed6" },
             "type": "color"
         },
         {
-            "id": "color__purple-600",
+            "id": "purple-600",
             "value": { "web": "#502095" },
             "type": "color"
         },
         {
-            "id": "color__green-100",
+            "id": "green-100",
             "value": { "web": "#e1fdf3" },
             "type": "color"
         },
         {
-            "id": "color__green-200",
+            "id": "green-200",
             "value": { "web": "#c6f7da" },
             "type": "color"
         },
         {
-            "id": "color__green-300",
+            "id": "green-300",
             "value": { "web": "#73e4a2" },
             "type": "color"
         },
         {
-            "id": "color__green",
+            "id": "green",
             "value": { "web": "#2db783" },
             "type": "color"
         },
         {
-            "id": "color__green-500",
+            "id": "green-500",
             "value": { "web": "#109e78" },
             "type": "color"
         },
         {
-            "id": "color__green-600",
+            "id": "green-600",
             "value": { "web": "#0f6648" },
             "type": "color"
         },
         {
-            "id": "color__yellow-100",
+            "id": "yellow-100",
             "value": { "web": "#fdf7e7" },
             "type": "color"
         },
         {
-            "id": "color__yellow-200",
+            "id": "yellow-200",
             "value": { "web": "#ffebb3" },
             "type": "color"
         },
         {
-            "id": "color__yellow-300",
+            "id": "yellow-300",
             "value": { "web": "#ffdd80" },
             "type": "color"
         },
         {
-            "id": "color__yellow",
+            "id": "yellow",
             "value": { "web": "#febe14" },
             "type": "color"
         },
         {
-            "id": "color__yellow-500",
+            "id": "yellow-500",
             "value": { "web": "#d48300" },
             "type": "color"
         },
         {
-            "id": "color__yellow-600",
+            "id": "yellow-600",
             "value": { "web": "#8a5500" },
             "type": "color"
         },
         {
-            "id": "color__red-100",
+            "id": "red-100",
             "value": { "web": "#ffeff0" },
             "type": "color"
         },
         {
-            "id": "color__red-200",
+            "id": "red-200",
             "value": { "web": "#ffd9d9" },
             "type": "color"
         },
         {
-            "id": "color__red-300",
+            "id": "red-300",
             "value": { "web": "#ffb0b0" },
             "type": "color"
         },
         {
-            "id": "color__red",
+            "id": "red",
             "value": { "web": "#ff5a5f" },
             "type": "color"
         },
         {
-            "id": "color__red-500",
+            "id": "red-500",
             "value": { "web": "#cc3553" },
             "type": "color"
         },
         {
-            "id": "color__red-600",
+            "id": "red-600",
             "value": { "web": "#76012c" },
             "type": "color"
         },
         {
-            "id": "color__black-300",
+            "id": "black-300",
             "value": { "web": "#676d73" },
             "type": "color"
         },
         {
-            "id": "color__black",
+            "id": "black",
             "value": { "web": "#2f3033" },
             "type": "color"
         },
         {
-            "id": "color__gray-200",
+            "id": "gray-200",
             "value": { "web": "#fafafa" },
             "type": "color"
         },
         {
-            "id": "color__gray-300",
+            "id": "gray-300",
             "value": { "web": "#e9eced" },
             "type": "color"
         },
         {
-            "id": "color__gray",
+            "id": "gray",
             "value": { "web": "#d3d4d5" },
             "type": "color"
         },
         {
-            "id": "color__white",
+            "id": "white",
             "value": { "web": "#ffffff" },
             "type": "color"
         }

--- a/packages/thumbprint-tokens/src/tokens/font-family.json
+++ b/packages/thumbprint-tokens/src/tokens/font-family.json
@@ -2,11 +2,11 @@
     "name": "Font Family",
     "tokens": [
         {
-            "id": "font-family__base",
+            "id": "base",
             "value": { "web": "Mark, Avenir, Helvetica, Arial, sans-serif" }
         },
         {
-            "id": "font-family__monospace",
+            "id": "monospace",
             "value": { "web": "'Source Code Pro', monospace" }
         }
     ]

--- a/packages/thumbprint-tokens/src/tokens/font-weight.json
+++ b/packages/thumbprint-tokens/src/tokens/font-weight.json
@@ -2,11 +2,11 @@
     "name": "Font Weight",
     "tokens": [
         {
-            "id": "font-weight__normal",
+            "id": "normal",
             "value": { "web": "400" }
         },
         {
-            "id": "font-weight__bold",
+            "id": "bold",
             "value": { "web": "700" }
         }
     ]

--- a/packages/thumbprint-tokens/src/tokens/font.json
+++ b/packages/thumbprint-tokens/src/tokens/font.json
@@ -3,197 +3,197 @@
     "tokens": [
         {
             "group": "Title 1",
-            "id": "font__title__1__size",
+            "id": "title__1__size",
             "value": { "web": "28px" }
         },
         {
             "group": "Title 1",
-            "id": "font__title__1__line-height",
+            "id": "title__1__line-height",
             "value": { "web": "32px" }
         },
         {
             "group": "Title 1",
-            "id": "font__title__1__weight",
+            "id": "title__1__weight",
             "value": { "web": "700" }
         },
         {
             "group": "Title 1",
-            "id": "font__title__1__responsive__size",
+            "id": "title__1__responsive__size",
             "value": { "web": "40px" }
         },
         {
             "group": "Title 1",
-            "id": "font__title__1__responsive__line-height",
+            "id": "title__1__responsive__line-height",
             "value": { "web": "44px" }
         },
         {
             "group": "Title 1",
-            "id": "font__title__1__responsive__weight",
+            "id": "title__1__responsive__weight",
             "value": { "web": "700" }
         },
         {
             "group": "Title 2",
-            "id": "font__title__2__size",
+            "id": "title__2__size",
             "value": { "web": "24px" }
         },
         {
             "group": "Title 2",
-            "id": "font__title__2__line-height",
+            "id": "title__2__line-height",
             "value": { "web": "28px" }
         },
         {
             "group": "Title 2",
-            "id": "font__title__2__weight",
+            "id": "title__2__weight",
             "value": { "web": "700" }
         },
         {
             "group": "Title 2",
-            "id": "font__title__2__responsive__size",
+            "id": "title__2__responsive__size",
             "value": { "web": "32px" }
         },
         {
             "group": "Title 2",
-            "id": "font__title__2__responsive__line-height",
+            "id": "title__2__responsive__line-height",
             "value": { "web": "40px" }
         },
         {
             "group": "Title 2",
-            "id": "font__title__2__responsive__weight",
+            "id": "title__2__responsive__weight",
             "value": { "web": "700" }
         },
         {
             "group": "Title 3",
-            "id": "font__title__3__size",
+            "id": "title__3__size",
             "value": { "web": "22px" }
         },
         {
             "group": "Title 3",
-            "id": "font__title__3__line-height",
+            "id": "title__3__line-height",
             "value": { "web": "28px" }
         },
         {
             "group": "Title 3",
-            "id": "font__title__3__weight",
+            "id": "title__3__weight",
             "value": { "web": "700" }
         },
         {
             "group": "Title 3",
-            "id": "font__title__3__responsive__size",
+            "id": "title__3__responsive__size",
             "value": { "web": "24px" }
         },
         {
             "group": "Title 3",
-            "id": "font__title__3__responsive__line-height",
+            "id": "title__3__responsive__line-height",
             "value": { "web": "32px" }
         },
         {
             "group": "Title 3",
-            "id": "font__title__3__responsive__weight",
+            "id": "title__3__responsive__weight",
             "value": { "web": "700" }
         },
         {
             "group": "Title 4",
-            "id": "font__title__4__size",
+            "id": "title__4__size",
             "value": { "web": "20px" }
         },
         {
             "group": "Title 4",
-            "id": "font__title__4__line-height",
+            "id": "title__4__line-height",
             "value": { "web": "28px" }
         },
         {
             "group": "Title 4",
-            "id": "font__title__4__weight",
+            "id": "title__4__weight",
             "value": { "web": "700" }
         },
         {
             "group": "Title 5",
-            "id": "font__title__5__size",
+            "id": "title__5__size",
             "value": { "web": "18px" }
         },
         {
             "group": "Title 5",
-            "id": "font__title__5__line-height",
+            "id": "title__5__line-height",
             "value": { "web": "24px" }
         },
         {
             "group": "Title 5",
-            "id": "font__title__5__weight",
+            "id": "title__5__weight",
             "value": { "web": "700" }
         },
         {
             "group": "Title 6",
-            "id": "font__title__6__size",
+            "id": "title__6__size",
             "value": { "web": "16px" }
         },
         {
             "group": "Title 6",
-            "id": "font__title__6__line-height",
+            "id": "title__6__line-height",
             "value": { "web": "24px" }
         },
         {
             "group": "Title 6",
-            "id": "font__title__6__weight",
+            "id": "title__6__weight",
             "value": { "web": "700" }
         },
         {
             "group": "Title 7",
-            "id": "font__title__7__size",
+            "id": "title__7__size",
             "value": { "web": "14px" }
         },
         {
             "group": "Title 7",
-            "id": "font__title__7__line-height",
+            "id": "title__7__line-height",
             "value": { "web": "20px" }
         },
         {
             "group": "Title 7",
-            "id": "font__title__7__weight",
+            "id": "title__7__weight",
             "value": { "web": "700" }
         },
         {
             "group": "Title 8",
-            "id": "font__title__8__size",
+            "id": "title__8__size",
             "value": { "web": "12px" }
         },
         {
             "group": "Title 8",
-            "id": "font__title__8__line-height",
+            "id": "title__8__line-height",
             "value": { "web": "18px" }
         },
         {
             "group": "Title 8",
-            "id": "font__title__8__weight",
+            "id": "title__8__weight",
             "value": { "web": "700" }
         },
         {
             "group": "Body 1",
-            "id": "font__body__1__size",
+            "id": "body__1__size",
             "value": { "web": "16px" }
         },
         {
             "group": "Body 1",
-            "id": "font__body__1__line-height",
+            "id": "body__1__line-height",
             "value": { "web": "24px" }
         },
         {
             "group": "Body 2",
-            "id": "font__body__2__size",
+            "id": "body__2__size",
             "value": { "web": "14px" }
         },
         {
             "group": "Body 2",
-            "id": "font__body__2__line-height",
+            "id": "body__2__line-height",
             "value": { "web": "20px" }
         },
         {
             "group": "Body 3",
-            "id": "font__body__3__size",
+            "id": "body__3__size",
             "value": { "web": "12px" }
         },
         {
             "group": "Body 3",
-            "id": "font__body__3__line-height",
+            "id": "body__3__line-height",
             "value": { "web": "18px" }
         }
     ]

--- a/packages/thumbprint-tokens/src/tokens/letter-spacing.json
+++ b/packages/thumbprint-tokens/src/tokens/letter-spacing.json
@@ -2,15 +2,15 @@
     "name": "Letter Spacing",
     "tokens": [
         {
-            "id": "letter-spacing__loose",
+            "id": "loose",
             "value": { "web": "1px" }
         },
         {
-            "id": "letter-spacing__tight",
+            "id": "tight",
             "value": { "web": "-1px" }
         },
         {
-            "id": "letter-spacing__extra-tight",
+            "id": "extra-tight",
             "value": { "web": "-2px" }
         }
     ]

--- a/packages/thumbprint-tokens/src/tokens/line-height.json
+++ b/packages/thumbprint-tokens/src/tokens/line-height.json
@@ -2,15 +2,15 @@
     "name": "Line Height",
     "tokens": [
         {
-            "id": "line-height__base",
+            "id": "base",
             "value": { "web": "1.6" }
         },
         {
-            "id": "line-height__tight",
+            "id": "tight",
             "value": { "web": "1.4" }
         },
         {
-            "id": "line-height__loose",
+            "id": "loose",
             "value": { "web": "1.9" }
         }
     ]

--- a/packages/thumbprint-tokens/src/tokens/shadow.json
+++ b/packages/thumbprint-tokens/src/tokens/shadow.json
@@ -2,7 +2,7 @@
     "name": "Shadow",
     "tokens": [
         {
-            "id": "shadow__card",
+            "id": "card",
             "value": { "web": "0 -1px 1px 0 rgba(0, 0, 0, 0.04), 0 1px 2px 0 rgba(0, 0, 0, 0.16)" }
         }
     ]

--- a/packages/thumbprint-tokens/src/tokens/space.json
+++ b/packages/thumbprint-tokens/src/tokens/space.json
@@ -2,35 +2,35 @@
     "name": "Space",
     "tokens": [
         {
-            "id": "space__1",
+            "id": "1",
             "value": { "web": "4px" }
         },
         {
-            "id": "space__2",
+            "id": "2",
             "value": { "web": "8px" }
         },
         {
-            "id": "space__3",
+            "id": "3",
             "value": { "web": "16px" }
         },
         {
-            "id": "space__4",
+            "id": "4",
             "value": { "web": "24px" }
         },
         {
-            "id": "space__5",
+            "id": "5",
             "value": { "web": "32px" }
         },
         {
-            "id": "space__6",
+            "id": "6",
             "value": { "web": "64px" }
         },
         {
-            "id": "space__7",
+            "id": "7",
             "value": { "web": "128px" }
         },
         {
-            "id": "space__8",
+            "id": "8",
             "value": { "web": "256px" }
         }
     ]

--- a/packages/thumbprint-tokens/src/tokens/wrap.json
+++ b/packages/thumbprint-tokens/src/tokens/wrap.json
@@ -2,11 +2,11 @@
     "name": "Wrap",
     "tokens": [
         {
-            "id": "wrap__max-width",
+            "id": "max-width",
             "value": { "web": "946px" }
         },
         {
-            "id": "wrap__no-pad-width",
+            "id": "no-pad-width",
             "value": { "web": "1010px" }
         }
     ]

--- a/packages/thumbprint-tokens/src/tokens/z-index.json
+++ b/packages/thumbprint-tokens/src/tokens/z-index.json
@@ -3,7 +3,7 @@
     "description": "Values to help stack Thumbprint UI components.",
     "tokens": [
         {
-            "id": "z-index__modal",
+            "id": "modal",
             "value": { "web": 200 }
         }
     ]

--- a/www/src/pages/tokens/javascript/index.mdx
+++ b/www/src/pages/tokens/javascript/index.mdx
@@ -45,7 +45,7 @@ export const pageQuery = graphql`
     {props.data.allThumbprintToken.edges.map(({ node: section }) => (
         <TokenSection
             section={section}
-            idTransform={id => camelCase(`tp-${id}`)}
+            idTransform={id => camelCase(`tp-${section.name}-${id}`)}
             key={section.name}
         />
     ))}

--- a/www/src/pages/tokens/scss/index.mdx
+++ b/www/src/pages/tokens/scss/index.mdx
@@ -42,6 +42,13 @@ export const pageQuery = graphql`
 
 <div>
     {props.data.allThumbprintToken.edges.map(({ node: section }) => (
-        <TokenSection section={section} idTransform={id => `$tp-${id}`} key={section.name} />
+        <TokenSection
+            section={section}
+            idTransform={id => {
+                const sectionName = section.name.replace(/\s+/g, '-').toLowerCase();
+                return `$tp-${sectionName}__${id}`;
+            }}
+            key={section.name}
+        />
     ))}
 </div>


### PR DESCRIPTION
The tokens output for SCSS and JavaScript will not change since this also updates Handlebars to now use the category name as part of the token name generation.

Doing this will allow us to support iOS since the token category will not be part of the token name.