### PR TITLE
Add image fade to onload

### DIFF
--- a/packages/thumbprint-react/CHANGELOG.md
+++ b/packages/thumbprint-react/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+-   [Minor] Add quick fade in of images onload.
+
 ### Changed
 
 -   [Patch] Update some token names that were renamed. This doesn't affect the outputted code.

--- a/packages/thumbprint-react/CHANGELOG.md
+++ b/packages/thumbprint-react/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
--   [Minor] Add quick fade in of images onload.
+-   [Minor] Add quick fade in transition to the `Image` component. (#243)
 
 ### Changed
 

--- a/packages/thumbprint-react/components/Image/components/picture.jsx
+++ b/packages/thumbprint-react/components/Image/components/picture.jsx
@@ -1,14 +1,29 @@
-import React, { forwardRef } from 'react';
+import React, { forwardRef, useState } from 'react';
+import styles from './picture.module.scss';
 
 const Picture = forwardRef((props, ref) => {
     const { src, sources, sizes, alt, style, ...rest } = props;
+
+    const [loadedClass, setClass] = useState(null);
+
+    function handleOnLoad() {
+        setClass(styles.imageLoaded);
+    }
 
     return (
         <picture>
             {sources.map(({ type, srcSet }) => (
                 <source type={type} srcSet={srcSet} key={type} sizes={sizes} />
             ))}
-            <img src={src} alt={alt} style={style} ref={ref} {...rest} />
+            <img
+                src={src}
+                alt={alt}
+                style={style}
+                ref={ref}
+                {...rest}
+                onLoad={handleOnLoad}
+                className={`${styles.imageLoading} ${loadedClass}`}
+            />
         </picture>
     );
 });

--- a/packages/thumbprint-react/components/Image/components/picture.jsx
+++ b/packages/thumbprint-react/components/Image/components/picture.jsx
@@ -4,11 +4,7 @@ import styles from './picture.module.scss';
 const Picture = forwardRef((props, ref) => {
     const { src, sources, sizes, alt, style, ...rest } = props;
 
-    const [loadedClass, setClass] = useState(null);
-
-    function handleOnLoad() {
-        setClass(styles.imageLoaded);
-    }
+    const [isLoaded, setIsLoaded] = useState(false);
 
     return (
         <picture>
@@ -21,8 +17,10 @@ const Picture = forwardRef((props, ref) => {
                 style={style}
                 ref={ref}
                 {...rest}
-                onLoad={handleOnLoad}
-                className={`${styles.imageLoading} ${loadedClass}`}
+                onLoad={() => {
+                    setIsLoaded(true);
+                }}
+                className={isLoaded ? styles.imageLoaded : styles.imageLoading}
             />
         </picture>
     );

--- a/packages/thumbprint-react/components/Image/components/picture.module.scss
+++ b/packages/thumbprint-react/components/Image/components/picture.module.scss
@@ -1,0 +1,8 @@
+.imageLoading {
+    opacity: 0;
+}
+
+.imageLoaded {
+    opacity: 1;
+    transition: opacity 300ms;
+}


### PR DESCRIPTION
Adds a 300ms fade in on the image so the loading isn't so abrupt. 

Will publish as a beta for testing.

Fixes #243