### PR TITLE
Temporarily bring back removed Tokens.

### DIFF
--- a/packages/thumbprint-tokens/CHANGELOG.md
+++ b/packages/thumbprint-tokens/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+-   [Patch] Temporarily bring back removed Tokens to make it easier to migrate to `8.0.0`.
+
 ## 8.0.0 - 2019-05-24
 
 ### Changed

--- a/packages/thumbprint-tokens/src/__snapshots__/index.test.js.snap
+++ b/packages/thumbprint-tokens/src/__snapshots__/index.test.js.snap
@@ -118,7 +118,13 @@ exports.tpSpace8 = \\"256px\\";
 exports.tpWrapMaxWidth = \\"946px\\";
 exports.tpWrapNoPadWidth = \\"1010px\\";
 exports.tpZIndexModal = 200;
-"
+
+exports.tpFontLetterSpacingLoose = \\"1px\\";
+exports.tpFontLetterSpacingTight = \\"-1px\\";
+exports.tpFontLetterSpacingExtraTight = \\"-2px\\";
+exports.tpFontLineHeightBase = \\"1.6\\";
+exports.tpFontLineHeightTight = \\"1.4\\";
+exports.tpFontLineHeightLoose = \\"1.9\\";"
 `;
 
 exports[`outputted ES module matches snapshot 1`] = `
@@ -239,7 +245,13 @@ export var tpSpace8 = \\"256px\\";
 export var tpWrapMaxWidth = \\"946px\\";
 export var tpWrapNoPadWidth = \\"1010px\\";
 export var tpZIndexModal = 200;
-"
+
+export var tpFontLetterSpacingLoose = \\"1px\\";
+export var tpFontLetterSpacingTight = \\"-1px\\";
+export var tpFontLetterSpacingExtraTight = \\"-2px\\";
+export var tpFontLineHeightBase = \\"1.6\\";
+export var tpFontLineHeightTight = \\"1.4\\";
+export var tpFontLineHeightLoose = \\"1.9\\";"
 `;
 
 exports[`outputted SCSS matches snapshot 1`] = `
@@ -360,5 +372,19 @@ $tp-space__8: 256px;
 $tp-wrap__max-width: 946px;
 $tp-wrap__no-pad-width: 1010px;
 $tp-z-index__modal: 200;
-"
+
+$tp-border__radius__base: 4px;
+$tp-border__radius__big: 6px;
+$tp-border__radius__full: 50%;
+$tp-border__radius__sides: 9999px;
+$tp-font__family__base: Mark, Avenir, Helvetica, Arial, sans-serif;
+$tp-font__family__monospace: 'Source Code Pro', monospace;
+$tp-font__letter-spacing__loose: 1px;
+$tp-font__letter-spacing__tight: -1px;
+$tp-font__letter-spacing__extra-tight: -2px;
+$tp-font__line-height__base: 1.6;
+$tp-font__line-height__tight: 1.4;
+$tp-font__line-height__loose: 1.9;
+$tp-font__weight__normal: 400;
+$tp-font__weight__bold: 700;"
 `;

--- a/packages/thumbprint-tokens/src/index.js
+++ b/packages/thumbprint-tokens/src/index.js
@@ -3,6 +3,9 @@ const path = require('path');
 const glob = require('glob');
 const fse = require('fs-extra');
 const handlebars = require('handlebars');
+// This import temporarily exists to help ease the migration from Tokens v7 to v8.
+// https://github.com/thumbtack/thumbprint/pull/242
+const tempTokens = require('./temp-tokens');
 
 const outputs = [
     { slug: 'javascript-cjs', distName: 'index.js' },
@@ -21,7 +24,7 @@ const compile = (output, tokens) => {
         handlebars.registerHelper(name, value);
     });
 
-    return handlebars.compile(template)(tokens);
+    return handlebars.compile(template)(tokens) + tempTokens[output];
 };
 
 (() => {

--- a/packages/thumbprint-tokens/src/temp-tokens.js
+++ b/packages/thumbprint-tokens/src/temp-tokens.js
@@ -1,0 +1,31 @@
+module.exports = {
+    'javascript-es': `
+export var tpFontLetterSpacingLoose = "1px";
+export var tpFontLetterSpacingTight = "-1px";
+export var tpFontLetterSpacingExtraTight = "-2px";
+export var tpFontLineHeightBase = "1.6";
+export var tpFontLineHeightTight = "1.4";
+export var tpFontLineHeightLoose = "1.9";`,
+    'javascript-cjs': `
+exports.tpFontLetterSpacingLoose = "1px";
+exports.tpFontLetterSpacingTight = "-1px";
+exports.tpFontLetterSpacingExtraTight = "-2px";
+exports.tpFontLineHeightBase = "1.6";
+exports.tpFontLineHeightTight = "1.4";
+exports.tpFontLineHeightLoose = "1.9";`,
+    scss: `
+$tp-border__radius__base: 4px;
+$tp-border__radius__big: 6px;
+$tp-border__radius__full: 50%;
+$tp-border__radius__sides: 9999px;
+$tp-font__family__base: Mark, Avenir, Helvetica, Arial, sans-serif;
+$tp-font__family__monospace: 'Source Code Pro', monospace;
+$tp-font__letter-spacing__loose: 1px;
+$tp-font__letter-spacing__tight: -1px;
+$tp-font__letter-spacing__extra-tight: -2px;
+$tp-font__line-height__base: 1.6;
+$tp-font__line-height__tight: 1.4;
+$tp-font__line-height__loose: 1.9;
+$tp-font__weight__normal: 400;
+$tp-font__weight__bold: 700;`,
+};


### PR DESCRIPTION
This is a hacky short term change that will make it easier to upgrade to Tokens v8 in website. I'm adding it in the JS file (rather than adding it to individual token JSON files) because now there is a required 1:1 mapping of file name to token prefix.

Will be cleaned up in #256.