### PR TITLE
Add changelog, release info, fix link

### DIFF
--- a/www/src/components/package-table/index.jsx
+++ b/www/src/components/package-table/index.jsx
@@ -13,10 +13,7 @@ import Tag from '../tag';
 const getChangelogURLFromPackageHomepageURL = homepageURL => {
     const parsedUrl = urlParse(homepageURL);
 
-    return pathJoin(
-        `${parsedUrl.protocol}//${parsedUrl.host}${parsedUrl.pathname}`,
-        'CHANGELOG.md',
-    );
+    return pathJoin(`${parsedUrl.protocol}//github.com/${parsedUrl.pathname}`, 'CHANGELOG.md');
 };
 
 const PackageTable = ({ version, deprecated, packageName, importStatement, sourceDirectory }) => {

--- a/www/src/components/package-table/index.jsx
+++ b/www/src/components/package-table/index.jsx
@@ -13,7 +13,7 @@ import Tag from '../tag';
 const getChangelogURLFromPackageHomepageURL = homepageURL => {
     const parsedUrl = urlParse(homepageURL);
 
-    return pathJoin(`${parsedUrl.protocol}//github.com/${parsedUrl.pathname}`, 'CHANGELOG.md');
+    return pathJoin(`https://github.com/${parsedUrl.pathname}`, 'CHANGELOG.md');
 };
 
 const PackageTable = ({ version, deprecated, packageName, importStatement, sourceDirectory }) => {

--- a/www/src/pages/overview/developers.mdx
+++ b/www/src/pages/overview/developers.mdx
@@ -37,3 +37,20 @@ If you cannot use React but want to include Thumbprint styling, for example, int
 ## Component deviations
 
 In some cases, like an experiment or a permanent one-off variation, you may want to change the appearance or behavior of Thumbprint component in an unsupported way. In this case you should avoid altering the Thumbprint SCSS or React components in your project and instead create a custom component. This is because future changes to the Thumbprint component could break altered instances.
+
+## Package updates
+
+### Changelogs
+
+All released and unreleased changes to our React, SCSS, and Atomic packages are tracked in their respective `CHANGELOG.md` files and is the best resource to determine the current status of the package.
+
+-   [React Changelog](https://github.com/thumbtack/thumbprint/blob/master/packages/thumbprint-react/CHANGELOG.md)
+-   [SCSS Changelog](https://github.com/thumbtack/thumbprint/blob/master/packages/thumbprint-scss/CHANGELOG.md)
+-   [Atomic Changelog](https://github.com/thumbtack/thumbprint/blob/master/packages/thumbprint-atomic/CHANGELOG.md)
+-   [Icons Changelog](https://github.com/thumbtack/thumbprint-icons/blob/master/CHANGELOG.md)
+
+Unreleased changes are often [published to npm](https://github.com/thumbtack/thumbprint/blob/master/RELEASING.md) within a day or two of merging into their packages.
+
+### Consumer updates
+
+The Design Systems team will update the package in our primary website, thumbtack.com, within a day or two of being published to npm. We handle this task because there are often migrations of varying complexity that we have the best context on. However, we may ask developers to do the update if the package’s changes are closely tied to a project they are working on.

--- a/www/src/pages/overview/developers.mdx
+++ b/www/src/pages/overview/developers.mdx
@@ -53,4 +53,4 @@ Unreleased changes are often [published to npm](https://github.com/thumbtack/thu
 
 ### Consumer updates
 
-The Design Systems team will update the package in our primary website, thumbtack.com, within a day or two of being published to npm. We handle this task because there are often migrations of varying complexity that we have the best context on. However, we may ask developers to do the update if the package’s changes are closely tied to a project they are working on.
+In most cases Design Systems team will update the package in our primary website, thumbtack.com, within a day or two of being published to npm. We handle this task because there are often migrations of varying complexity that we have the best context on. However, on occasion we may ask developers to do the update if the package’s changes are closely tied to a project they are working on.


### PR DESCRIPTION
@danoc I tested out a fix for the CHANGELOG.md links but I see even hardcoding the host doesn't get around the hostname problem. If you can fix it quickly please add here, otherwise I will revert that file in this PR. 

***
Fixes https://github.com/thumbtack/thumbprint/issues/102