### PR TITLE
Add `1px` min-height to the Image component.

### DIFF
--- a/packages/thumbprint-react/CHANGELOG.md
+++ b/packages/thumbprint-react/CHANGELOG.md
@@ -11,6 +11,10 @@
 -   [Patch] Add small delay before showing tooltip after hovering to prevent flickering. (#158)
 -   [Patch] Redesign the avatar with initials design to use dynamic colours. (#25)
 
+### Fixed
+
+-   [Patch] Add `1px` min-height to the Image component root element to improve lazy-loading.
+
 ## 2.1.0 - 2019-06-04
 
 ### Added

--- a/packages/thumbprint-react/components/Image/index.jsx
+++ b/packages/thumbprint-react/components/Image/index.jsx
@@ -43,6 +43,9 @@ const Image = forwardRef((props, outerRef) => {
             // passing a `border-radius` in `className` or `style` would not work since the
             // container is a `div`, not an `img`.
             overflow: 'hidden',
+            // Setting a `min-height` makes the lazy-loading work in cases where the `Image` parent
+            // has a `0px` height.
+            minHeight: '1px',
         },
     };
 


### PR DESCRIPTION
This improves lazy-loading, fixing scenarios where an `Image` is within a parent that has `0px` height.