### PR TITLE
Fix Image component in IE 11.

### DIFF
--- a/packages/thumbprint-react/CHANGELOG.md
+++ b/packages/thumbprint-react/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+-   [Patch] Fix `Image` component in IE 11.
+
 ## 3.1.0 - 2019-06-06
 
 ### Added

--- a/packages/thumbprint-react/components/Image/components/picture.jsx
+++ b/packages/thumbprint-react/components/Image/components/picture.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import find from 'lodash/find';
 import styles from './picture.module.scss';
 
 const Picture = props => {
@@ -9,8 +10,8 @@ const Picture = props => {
     // Safari:
     // - https://bugs.webkit.org/show_bug.cgi?id=190031
     // - https://bugs.webkit.org/show_bug.cgi?id=177068
-    const webpSource = sources.find(s => s.type === 'image/webp');
-    const imgTagSource = sources.find(s => s.type === 'image/jpeg' || s.type === 'image/png');
+    const webpSource = find(sources, s => s.type === 'image/webp');
+    const imgTagSource = find(sources, s => s.type === 'image/jpeg' || s.type === 'image/png');
 
     const [isLoaded, setIsLoaded] = useState(false);
 


### PR DESCRIPTION
IE 11 does not support `Array.find`. 

This is the same code as the hotfix I published in `2.2.1`. That version release was not done on `master`, so I need to do this to get the fix in `master`.