### PR TITLE
Exit instead of returning in the codemod CLI.

### DIFF
--- a/packages/thumbprint-codemods/CHANGELOG.md
+++ b/packages/thumbprint-codemods/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+-   [Patch] Exit instead of returning in the CLI.
+
 ## 0.3.1 - 2019-06-11
 
 ### Fixed

--- a/packages/thumbprint-codemods/index.js
+++ b/packages/thumbprint-codemods/index.js
@@ -49,7 +49,7 @@ Examples
 // A glob is required
 if (cli.input.length === 0) {
     cli.showHelp();
-    return;
+    process.exit();
 }
 
 // Throw an error if the codemod name isn't valid


### PR DESCRIPTION
This fixes an issue I was running into when running `yarn start`. The error I got was saying that it's not valid to return in this case because the code is not inside a function.