### PR TITLE
Remove unused CSS from `ServiceCardImage`.

### DIFF
--- a/packages/thumbprint-react/CHANGELOG.md
+++ b/packages/thumbprint-react/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+-   [Patch] Remove unused CSS from `ServiceCardImage`.
+
 ## 3.1.2 - 2019-06-11
 
 ### Fixed

--- a/packages/thumbprint-react/components/ServiceCard/index.module.scss
+++ b/packages/thumbprint-react/components/ServiceCard/index.module.scss
@@ -10,11 +10,8 @@
 }
 
 .image {
-    height: 0;
-    padding-bottom: 62.5%; // 8x5 aspect ratio
     border-radius: $tp-border-radius__base;
     margin-bottom: $tp-space__2;
-    background-size: cover;
 }
 
 .title {


### PR DESCRIPTION
Forgot to remove this in #279.

It is still relevant even when we merge #301.