### PR TITLE
Deprecate ServiceCardImage url in favor of src

### DIFF
--- a/packages/thumbprint-react/CHANGELOG.md
+++ b/packages/thumbprint-react/CHANGELOG.md
@@ -8,6 +8,8 @@
 -   [Major] Only include `object-fit` CSS in `Image` when `height` is provided. That CSS was previously being added when the `containerAspectRatio` was present. `containerAspectRatio` now only adds placeholder spacing on the `<img>` which is removed `onload`.
 -   [Major] Remove CSS that enforced aspect ratio in `ServiceCardImage` due to changes in `Image` component that no longer support this use case.
 -   [Major] `ServiceCardImage` requires an image in the 8:5 aspect ratio to render correctly.
+-   [Minor] `ServiceCardImage` prop `src` added to replace `src`.
+-   [Patch] `ServiceCardImage` prop `url` deprecated.
 
 ## 5.0.0 - 2019-06-13
 

--- a/packages/thumbprint-react/components/ServiceCard/__snapshots__/test.jsx.snap
+++ b/packages/thumbprint-react/components/ServiceCard/__snapshots__/test.jsx.snap
@@ -71,7 +71,7 @@ exports[`ServiceCardDescription renders icon color 1`] = `
 exports[`ServiceCardImage render works 1`] = `
 <ServiceCardImage
   alt="duck duck goose"
-  url="https://www.thumbtack.com/image.png"
+  src="https://www.thumbtack.com/image.png"
 >
   <Image
     alt="duck duck goose"

--- a/packages/thumbprint-react/components/ServiceCard/index.jsx
+++ b/packages/thumbprint-react/components/ServiceCard/index.jsx
@@ -75,8 +75,8 @@ ServiceCard.defaultProps = {
 
 ServiceCardImage.propTypes = {
     /**
-     * DEPRECATED - URL pointing to image to be displayed. This image must have an aspect
-     * ratio of 8:5.
+     * URL pointing to image to be displayed. This image must have an aspect ratio of 8:5.
+     * @deprecated Use `src` instead of `url`.
      */
     url: PropTypes.string,
     /**

--- a/packages/thumbprint-react/components/ServiceCard/index.jsx
+++ b/packages/thumbprint-react/components/ServiceCard/index.jsx
@@ -4,12 +4,12 @@ import classNames from 'classnames';
 import Image from '../Image/index.jsx';
 import styles from './index.module.scss';
 
-const ServiceCardImage = ({ url, sources, alt }) => (
+const ServiceCardImage = ({ url, src, sources, alt }) => (
     <Image
         className={styles.image}
         sources={sources}
         containerAspectRatio={8 / 5}
-        src={url}
+        src={url || src} // `url` deprecated
         alt={alt}
     />
 );
@@ -75,9 +75,14 @@ ServiceCard.defaultProps = {
 
 ServiceCardImage.propTypes = {
     /**
+     * DEPRECATED - URL pointing to image to be displayed. This image must have an aspect
+     * ratio of 8:5.
+     */
+    url: PropTypes.string,
+    /**
      * URL pointing to image to be displayed. This image must have an aspect ratio of 8:5.
      */
-    url: PropTypes.string.isRequired,
+    src: PropTypes.string,
     /**
      * Allows the browser to choose the best file format and image size based on the device screen
      * density and the width of the rendered image. Images must have an aspect ratio of 8:5.
@@ -98,6 +103,8 @@ ServiceCardImage.propTypes = {
 ServiceCardImage.defaultProps = {
     alt: undefined,
     sources: undefined,
+    url: undefined,
+    src: undefined,
 };
 
 ServiceCardTitle.propTypes = {

--- a/packages/thumbprint-react/components/ServiceCard/test.jsx
+++ b/packages/thumbprint-react/components/ServiceCard/test.jsx
@@ -42,7 +42,7 @@ describe('ServiceCard', () => {
 describe('ServiceCardImage', () => {
     test('render works', () => {
         const wrapper = mount(
-            <ServiceCardImage alt="duck duck goose" url="https://www.thumbtack.com/image.png" />,
+            <ServiceCardImage alt="duck duck goose" src="https://www.thumbtack.com/image.png" />,
         );
 
         expect(wrapper).toMatchSnapshot();

--- a/www/src/components/thumbprint-components/component-footer/index.jsx
+++ b/www/src/components/thumbprint-components/component-footer/index.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Text } from '@thumbtack/thumbprint-react';
-import { isString, get } from 'lodash';
+import { isString, get, find } from 'lodash';
 import Tag from '../../tag';
 import { MDXRenderer, InlineCode, H2, H3 } from '../../mdx';
 import PropType from './prop-type';
@@ -25,66 +25,71 @@ const ComponentFooter = ({ data }) => {
                         </div>
                     )}
                     <ul>
-                        {component.props.map(prop => (
-                            <li className="bb b-gray-300 pv3" key={prop.name}>
-                                <div className="flex">
-                                    <div className="b">
-                                        <InlineCode shouldCopyToClipboard theme="plain">
-                                            {prop.name}
-                                        </InlineCode>
-                                    </div>
-                                    {prop.required && (
-                                        <div className="ml2">
-                                            <Tag type="required" />
-                                        </div>
-                                    )}
-                                    {prop.doclets.deprecated && (
-                                        <div className="ml2">
-                                            <Tag type="deprecated" />
-                                        </div>
-                                    )}
-                                </div>
-                                <div className="black-300 mw8 mb2">
-                                    {prop.description && (
-                                        <MDXRenderer>
-                                            {prop.description.childMdx.code.body}
-                                        </MDXRenderer>
-                                    )}
+                        {component.props.map(prop => {
+                            const deprecated = find(prop.doclets, o => o.tag === 'deprecated');
+                            console.log({ deprecated });
 
-                                    {isString(prop.doclets.deprecated) && (
-                                        <p>
-                                            <b>Note:</b> {prop.doclets.deprecated}
-                                        </p>
-                                    )}
-                                </div>
-                                <div className="flex">
-                                    {prop.type && (
-                                        <Text
-                                            className="black-300 mr4 w-50 s_w-40 m_w-30 m_w-20"
-                                            elementName="div"
-                                        >
-                                            <InlineCode theme="plain">Type</InlineCode>
-                                            <div className="b">
-                                                <PropType
-                                                    type={prop.type.name}
-                                                    value={prop.type.value}
-                                                />
+                            return (
+                                <li className="bb b-gray-300 pv3" key={prop.name}>
+                                    <div className="flex">
+                                        <div className="b">
+                                            <InlineCode shouldCopyToClipboard theme="plain">
+                                                {prop.name}
+                                            </InlineCode>
+                                        </div>
+                                        {prop.required && (
+                                            <div className="ml2">
+                                                <Tag type="required" />
                                             </div>
-                                        </Text>
-                                    )}
-                                    {get(prop.defaultValue, 'value') && (
-                                        <Text className="black-300" elementName="div">
-                                            <InlineCode theme="plain">Default</InlineCode>
-                                            <div className="indigo b">
-                                                <InlineCode theme="plain">
-                                                    {get(prop.defaultValue, 'value')}
-                                                </InlineCode>
+                                        )}
+                                        {deprecated && (
+                                            <div className="ml2">
+                                                <Tag type="deprecated" />
                                             </div>
-                                        </Text>
-                                    )}
-                                </div>
-                            </li>
-                        ))}
+                                        )}
+                                    </div>
+                                    <div className="black-300 mw8 mb2">
+                                        {prop.description && (
+                                            <MDXRenderer>
+                                                {prop.description.childMdx.code.body}
+                                            </MDXRenderer>
+                                        )}
+
+                                        {deprecated && isString(deprecated.value) && (
+                                            <p>
+                                                <b>Note:</b> {deprecated.value}
+                                            </p>
+                                        )}
+                                    </div>
+                                    <div className="flex">
+                                        {prop.type && (
+                                            <Text
+                                                className="black-300 mr4 w-50 s_w-40 m_w-30 m_w-20"
+                                                elementName="div"
+                                            >
+                                                <InlineCode theme="plain">Type</InlineCode>
+                                                <div className="b">
+                                                    <PropType
+                                                        type={prop.type.name}
+                                                        value={prop.type.value}
+                                                    />
+                                                </div>
+                                            </Text>
+                                        )}
+                                        {get(prop.defaultValue, 'value') && (
+                                            <Text className="black-300" elementName="div">
+                                                <InlineCode theme="plain">Default</InlineCode>
+                                                <div className="indigo b">
+                                                    <InlineCode theme="plain">
+                                                        {get(prop.defaultValue, 'value')}
+                                                    </InlineCode>
+                                                </div>
+                                            </Text>
+                                        )}
+                                    </div>
+                                </li>
+                            );
+                        })}
                     </ul>
                 </div>
             ))}

--- a/www/src/pages/components/service-card/react/index.mdx
+++ b/www/src/pages/components/service-card/react/index.mdx
@@ -14,6 +14,10 @@ import Alert from 'components/alert';
     aspect ratio is used the mismatch will cause a layout shift when the image loads.
 </Alert>
 
+<Alert type="warning" title="Deprecated prop">
+    The <b>url</b> prop in <b>ServceCardImage</b> has been deprecated in favor of <b>src</b>.
+</Alert>
+
 ## With icon
 
 ```jsx
@@ -22,7 +26,7 @@ import Alert from 'components/alert';
         <ServiceCard url="https://www.thumbtack.com/k/massage/near-me/">
             <ServiceCardImage
                 alt="Sprinkler and Irrigation System Repair and Maintenance"
-                url="https://d1vg1gqh4nkuns.cloudfront.net/i/318810408927723609/width/1024/aspect/8-5.jpeg"
+                src="https://d1vg1gqh4nkuns.cloudfront.net/i/318810408927723609/width/1024/aspect/8-5.jpeg"
             />
             <ServiceCardTitle>
                 Sprinkler and Irrigation System Repair and Maintenance
@@ -36,7 +40,7 @@ import Alert from 'components/alert';
         <ServiceCard url="https://www.thumbtack.com/k/massage/near-me/">
             <ServiceCardImage
                 alt="Sprinkler and Irrigation System Repair and Maintenance"
-                url="https://d1vg1gqh4nkuns.cloudfront.net/i/318810408927723609/width/1024/aspect/8-5.jpeg"
+                src="https://d1vg1gqh4nkuns.cloudfront.net/i/318810408927723609/width/1024/aspect/8-5.jpeg"
             />
             <ServiceCardTitle>
                 Sprinkler and Irrigation System Repair and Maintenance
@@ -56,7 +60,7 @@ import Alert from 'components/alert';
     <ServiceCard url="https://www.thumbtack.com/k/massage/near-me/">
         <ServiceCardImage
             alt="Sprinkler and Irrigation System Repair and Maintenance"
-            url="https://d1vg1gqh4nkuns.cloudfront.net/i/318810408927723609/width/1024/aspect/8-5.jpeg"
+            src="https://d1vg1gqh4nkuns.cloudfront.net/i/318810408927723609/width/1024/aspect/8-5.jpeg"
         />
         <ServiceCardTitle>Sprinkler and Irrigation System Repair and Maintenance</ServiceCardTitle>
         <ServiceCardDescription>
@@ -77,7 +81,7 @@ import Alert from 'components/alert';
     >
         <ServiceCardImage
             alt="Sprinkler and Irrigation System Repair and Maintenance"
-            url="https://d1vg1gqh4nkuns.cloudfront.net/i/318810408927723609/small/standard/hero"
+            src="https://d1vg1gqh4nkuns.cloudfront.net/i/318810408927723609/small/standard/hero"
         />
         <ServiceCardTitle>Sprinkler and Irrigation System Repair and Maintenance</ServiceCardTitle>
         <ServiceCardDescription>

--- a/www/src/pages/components/service-card/react/index.mdx
+++ b/www/src/pages/components/service-card/react/index.mdx
@@ -14,10 +14,6 @@ import Alert from 'components/alert';
     aspect ratio is used the mismatch will cause a layout shift when the image loads.
 </Alert>
 
-<Alert type="warning" title="Deprecated prop">
-    The <b>url</b> prop in <b>ServceCardImage</b> has been deprecated in favor of <b>src</b>.
-</Alert>
-
 ## With icon
 
 ```jsx


### PR DESCRIPTION
Do have a way of rendering a `deprecated` tag for props? Looks like we can via https://github.com/thumbtack/thumbprint/blob/e9016e6b8589710641dbd7ded6434095dab5cdf0/www/src/components/thumbprint-components/component-footer/index.jsx#L41 but wasn't sure what the doclet syntax looked like, couldn't find an existing example. 