### PR TITLE
Remove notice about codemods being forked

### DIFF
--- a/packages/thumbprint-codemods/README.md
+++ b/packages/thumbprint-codemods/README.md
@@ -1,8 +1,6 @@
-# thumbprint-codemods
+# Thumbprint Codemods
 
 This package is a collection of codemods that assist with breaking changes in Thumbprint.
-
-The CLI and the `thumbprint-react-consolidation` codemod are forked from [`segment-migration`](https://github.com/segmentio/evergreen-migration) and customized for Thumbtack's needs.
 
 ## Usage
 


### PR DESCRIPTION
We've removed the referenced codemod and rewrote the CLI.