### PR TITLE
Support union PropTypes in documentation.

### DIFF
--- a/www/src/components/thumbprint-components/component-footer/index.jsx
+++ b/www/src/components/thumbprint-components/component-footer/index.jsx
@@ -63,27 +63,25 @@ const ComponentFooter = ({ data }) => {
                                     <div className="flex">
                                         {prop.type && (
                                             <Text
-                                                className="black-300 mr4 w-50 s_w-40 m_w-30 m_w-20"
+                                                className="mr4 w-50 s_w-40 m_w-30 m_w-20"
                                                 elementName="div"
                                             >
-                                                <InlineCode theme="plain">Type</InlineCode>
-                                                <div className="b">
-                                                    <PropType
-                                                        type={prop.type.name}
-                                                        value={prop.type.value}
-                                                    />
-                                                </div>
+                                                <div className="b">Type</div>
+                                                <PropType
+                                                    type={prop.type.name}
+                                                    value={prop.type.value}
+                                                />
                                             </Text>
                                         )}
                                         {get(prop.defaultValue, 'value') && (
-                                            <Text className="black-300" elementName="div">
-                                                <InlineCode theme="plain">Default</InlineCode>
-                                                <div className="indigo b">
+                                            <div>
+                                                <div className="b">Default</div>
+                                                <div className="black-300">
                                                     <InlineCode theme="plain">
                                                         {get(prop.defaultValue, 'value')}
                                                     </InlineCode>
                                                 </div>
-                                            </Text>
+                                            </div>
                                         )}
                                     </div>
                                 </li>

--- a/www/src/components/thumbprint-components/component-footer/prop-type.jsx
+++ b/www/src/components/thumbprint-components/component-footer/prop-type.jsx
@@ -1,26 +1,75 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { map } from 'lodash';
+import { Text } from '@thumbtack/thumbprint-react';
 import { InlineCode } from '../../mdx';
+import styles from './prop-type.module.scss';
 
-const PropType = ({ type, value }) => {
-    if (type === 'enum') {
-        const enumValues = map(value, 'value');
-
-        return (
-            <pre className="black-300">
-                <InlineCode theme="plain">{`oneOf([
-  ${enumValues.join(',\n  ')},
-]);`}</InlineCode>
-            </pre>
-        );
-    }
+const EnumPropType = ({ value }) => {
+    const enumValues = value.map(valObj => valObj.value);
 
     return (
-        <span className="black-300">
-            <InlineCode theme="plain">{type}</InlineCode>
-        </span>
+        <pre>
+            <InlineCode theme="plain">{`oneOf([
+  ${enumValues.join(',\n  ')},
+])`}</InlineCode>
+        </pre>
     );
+};
+
+EnumPropType.propTypes = {
+    value: PropTypes.arrayOf(
+        PropTypes.shape({
+            value: PropTypes.string.isRequired,
+        }),
+    ).isRequired,
+};
+
+const DefaultPropType = ({ value }) => <InlineCode theme="plain">{value}</InlineCode>;
+
+DefaultPropType.propTypes = {
+    value: PropTypes.string.isRequired,
+};
+
+const UnionPropType = ({ value }) => (
+    <div>
+        <Text size={1} className="mb1">
+            This prop has {value.length} types:
+        </Text>
+        <ul className={styles.unionPropType}>
+            {value.map(type => {
+                let component;
+
+                if (type.name === 'enum') {
+                    component = <EnumPropType value={type.value} />;
+                } else {
+                    component = <DefaultPropType value={type.name} />;
+                }
+
+                return <li key={type.name}>{component}</li>;
+            })}
+        </ul>
+    </div>
+);
+
+UnionPropType.propTypes = {
+    value: PropTypes.shape({
+        name: PropTypes.string.isRequired,
+        value: PropTypes.array,
+    }).isRequired,
+};
+
+const PropType = ({ type, value }) => {
+    let component;
+
+    if (type === 'enum') {
+        component = <EnumPropType value={value} />;
+    } else if (type === 'union') {
+        component = <UnionPropType value={value} />;
+    } else {
+        component = <DefaultPropType value={type} />;
+    }
+
+    return <div className="black-300">{component}</div>;
 };
 
 PropType.propTypes = {

--- a/www/src/components/thumbprint-components/component-footer/prop-type.module.scss
+++ b/www/src/components/thumbprint-components/component-footer/prop-type.module.scss
@@ -1,0 +1,6 @@
+@import '~@thumbtack/thumbprint-tokens/dist/scss/_index';
+
+.unionPropType {
+    list-style: disc;
+    padding-left: $tp-space__4;
+}


### PR DESCRIPTION
This also slightly re-designs the PropType "Type" and "Default" section so that the default value is not emphasized over the prop name, description, and type.

Fixes #311.

***

**Example with just an `enum`:**
<img width="625" alt="image" src="https://user-images.githubusercontent.com/916038/59728336-7dc7c980-91ee-11e9-9e83-de9df10efcf2.png">

**Example with a union including an `enum` and `number`:**
<img width="491" alt="image" src="https://user-images.githubusercontent.com/916038/59728338-802a2380-91ee-11e9-91f5-300806d2dc60.png">
