### PR TITLE
Avatar documentation clean-up

### DIFF
--- a/packages/thumbprint-react/CHANGELOG.md
+++ b/packages/thumbprint-react/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+-   [Patch] Update description of Avatar prop.
+
 ## 6.3.2 - 2019-07-01
 
 ### Changed

--- a/packages/thumbprint-react/components/Avatar/index.jsx
+++ b/packages/thumbprint-react/components/Avatar/index.jsx
@@ -108,7 +108,7 @@ EntityAvatar.propTypes = {
      */
     initial: PropTypes.string,
     /**
-     * The user's full name. This is used as `title` and `alt` text.
+     * The entity's full name. This is used as `title` and `alt` text.
      */
     fullName: PropTypes.string,
     /**

--- a/www/src/pages/components/avatar/react/index.mdx
+++ b/www/src/pages/components/avatar/react/index.mdx
@@ -12,155 +12,115 @@ import {
 
 <ComponentHeader data={props.data} />
 
-## Avatar Sizes
+## Avatar variations
 
-### Extra Large
+Avatars are available as two components: `UserAvatar` and `EntityAvatar`.
 
 ```jsx
 <UserAvatar imageUrl="https://www.placecage.com/640/480" size="xlarge" />
 ```
 
-### Large
+`UserAvatar` is for people or users whereas `EntityAvatar` is for companies, businesses, or services.
+
+## Avatar sizes
+
+Both `UserAvatar` and `EntityAvatar` are available in five sizes ranging from `xlarge` to `xsmall`.
 
 ```jsx
-<UserAvatar imageUrl="https://www.placecage.com/640/480" size="large" />
-```
-
-### Medium
-
-```jsx
-<UserAvatar imageUrl="https://www.placecage.com/640/480" size="medium" />
-```
-
-### Small
-
-```jsx
-<UserAvatar imageUrl="https://www.placecage.com/640/480" size="small" />
-```
-
-### Extra Small
-
-```jsx
-<UserAvatar imageUrl="https://www.placecage.com/640/480" size="xsmall" />
+<>
+    <div className="flex items-center mb4">
+        <div className="mr3">
+            <UserAvatar imageUrl="https://www.placecage.com/640/480" size="xlarge" />
+        </div>
+        <div className="mr3">
+            <UserAvatar imageUrl="https://www.placecage.com/640/480" size="large" />
+        </div>
+        <div className="mr3">
+            <UserAvatar imageUrl="https://www.placecage.com/640/480" size="medium" />
+        </div>
+        <div className="mr3">
+            <UserAvatar imageUrl="https://www.placecage.com/640/480" size="small" />
+        </div>
+        <div className="mr3">
+            <UserAvatar imageUrl="https://www.placecage.com/640/480" size="xsmall" />
+        </div>
+    </div>
+    <div className="flex items-center">
+        <div className="mr3">
+            <EntityAvatar imageUrl="https://www.placecage.com/640/480" size="xlarge" />
+        </div>
+        <div className="mr3">
+            <EntityAvatar imageUrl="https://www.placecage.com/640/480" size="large" />
+        </div>
+        <div className="mr3">
+            <EntityAvatar imageUrl="https://www.placecage.com/640/480" size="medium" />
+        </div>
+        <div className="mr3">
+            <EntityAvatar imageUrl="https://www.placecage.com/640/480" size="small" />
+        </div>
+        <div className="mr3">
+            <EntityAvatar imageUrl="https://www.placecage.com/640/480" size="xsmall" />
+        </div>
+    </div>
+</>
 ```
 
 ## Avatars without images
 
-When a user does not have an image, an `Avatar` can display the user’s initials instead. The initals are assigned to a color based on the first letter in the `initials` prop.
+Avatars without images can display the the user or entity’s initials instead. The initals are assigned to a color based on the first letter in the `initials` prop.
 
 ```jsx
-<div className="flex items-center">
-    <div className="mr2">
-        <UserAvatar initials="AA" size="xlarge" />
+<>
+    <div className="flex mb4">
+        <div className="mr2">
+            <UserAvatar initials="AA" size="large" />
+        </div>
+        <div className="mr2">
+            <UserAvatar initials="BA" size="large" />
+        </div>
+        <div className="mr2">
+            <UserAvatar initials="CA" size="large" />
+        </div>
+        <div className="mr2">
+            <UserAvatar initials="DA" size="large" />
+        </div>
+        <div className="mr2">
+            <UserAvatar initials="EA" size="large" />
+        </div>
+        <div>
+            <UserAvatar initials="HA" size="large" />
+        </div>
     </div>
-    <div className="mr2">
-        <UserAvatar initials="BA" size="large" />
+    <div className="flex">
+        <div className="mr2">
+            <EntityAvatar initial="A" size="large" />
+        </div>
+        <div className="mr2">
+            <EntityAvatar initial="B" size="large" />
+        </div>
+        <div className="mr2">
+            <EntityAvatar initial="C" size="large" />
+        </div>
+        <div className="mr2">
+            <EntityAvatar initial="D" size="large" />
+        </div>
+        <div className="mr2">
+            <EntityAvatar initial="E" size="large" />
+        </div>
+        <div>
+            <EntityAvatar initial="F" size="large" />
+        </div>
     </div>
-    <div className="mr2">
-        <UserAvatar initials="CA" size="medium" />
-    </div>
-    <div className="mr2">
-        <UserAvatar initials="DA" size="small" />
-    </div>
-    <div className="mr2">
-        <UserAvatar initials="EA" size="xsmall" />
-    </div>
-    <div>
-        <UserAvatar initials="HA" size="xsmall" />
-    </div>
-</div>
+</>
 ```
 
-## EntityAvatar
-
-### Extra Large
-
-```jsx
-<EntityAvatar imageUrl="https://www.placecage.com/640/480" size="xlarge" />
-```
-
-### Large
-
-```jsx
-<EntityAvatar imageUrl="https://www.placecage.com/640/480" size="large" />
-```
-
-### Medium
-
-```jsx
-<EntityAvatar imageUrl="https://www.placecage.com/640/480" size="medium" />
-```
-
-### Small
-
-```jsx
-<EntityAvatar imageUrl="https://www.placecage.com/640/480" size="small" />
-```
-
-### Extra Small
-
-```jsx
-<EntityAvatar imageUrl="https://www.placecage.com/640/480" size="xsmall" />
-```
-
-### Initials
-
-```jsx
-<div className="flex">
-    <div className="mr2">
-        <EntityAvatar initial="A" size="large" />
-    </div>
-    <div className="mr2">
-        <EntityAvatar initial="B" size="large" />
-    </div>
-    <div className="mr2">
-        <EntityAvatar initial="C" size="large" />
-    </div>
-    <div className="mr2">
-        <EntityAvatar initial="D" size="large" />
-    </div>
-    <div className="mr2">
-        <EntityAvatar initial="E" size="large" />
-    </div>
-    <div>
-        <EntityAvatar initial="F" size="large" />
-    </div>
-</div>
-```
-
-## Avatar Badges
-
-<DeprecatedComponentAlert>
-    The checked badge is deprecated. To indicate hired status of a user, show this information
-    separately next to the avatar. Only the online badge is supported by both components. Checked is
-    only supported by UserAvatar.
-</DeprecatedComponentAlert>
+## Avatar badges
 
 Badges can be added to avatars to denote information including hired status and online status.
 
-### Checked
-
-```jsx
-<div className="flex items-center mb4">
-    <div className="mr2">
-        <UserAvatar imageUrl="https://www.placecage.com/640/480" isChecked size="xlarge" />
-    </div>
-    <div className="mr2">
-        <UserAvatar imageUrl="https://www.placecage.com/640/480" isChecked size="large" />
-    </div>
-    <div className="mr2">
-        <UserAvatar imageUrl="https://www.placecage.com/640/480" isChecked size="medium" />
-    </div>
-    <div className="mr2">
-        <UserAvatar imageUrl="https://www.placecage.com/640/480" isChecked size="small" />
-    </div>
-    <div className="mr2">
-        <UserAvatar imageUrl="https://www.placecage.com/640/480" isChecked size="xsmall" />
-    </div>
-</div>
-```
-
 ### Online
+
+This badge indicates that a user or entity is online.
 
 ```jsx
 <div>
@@ -198,6 +158,34 @@ Badges can be added to avatars to denote information including hired status and 
         <div className="mr2">
             <EntityAvatar imageUrl="https://www.placecage.com/640/480" isOnline size="xsmall" />
         </div>
+    </div>
+</div>
+```
+
+### Checked
+
+<DeprecatedComponentAlert>
+    The checked badge is deprecated. To indicate hired status of a user, show this information
+    separately next to the avatar. Only the online badge is supported by both components. Checked is
+    only supported by UserAvatar.
+</DeprecatedComponentAlert>
+
+```jsx
+<div className="flex items-center mb4">
+    <div className="mr2">
+        <UserAvatar imageUrl="https://www.placecage.com/640/480" isChecked size="xlarge" />
+    </div>
+    <div className="mr2">
+        <UserAvatar imageUrl="https://www.placecage.com/640/480" isChecked size="large" />
+    </div>
+    <div className="mr2">
+        <UserAvatar imageUrl="https://www.placecage.com/640/480" isChecked size="medium" />
+    </div>
+    <div className="mr2">
+        <UserAvatar imageUrl="https://www.placecage.com/640/480" isChecked size="small" />
+    </div>
+    <div className="mr2">
+        <UserAvatar imageUrl="https://www.placecage.com/640/480" isChecked size="xsmall" />
     </div>
 </div>
 ```


### PR DESCRIPTION
This started off as a small tweak but I ended up re-writing most of the documentation.

The main change is that the page is no longer `UserAvatar` first followed by a section on `EntityAvatar`. Both are now documented together. I've also consolidated the size examples into a single example, making it easier to scan the page.