### PR TITLE
Remove default fade in on Image

### DIFF
--- a/packages/thumbprint-react/CHANGELOG.md
+++ b/packages/thumbprint-react/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 -   [Patch] Update `ConditionalPortal` to explicitly allow and handle null contents. (#357)
 -   [Patch] Update description of Avatar prop.
+-   [Minor] `Image` no longer fades in by default, added `fadeIn` prop if that behavior is desired. `ServiceCardImage` and `Avatar`, which use `Image` under the hood, also no longer fade in by default. (#368)
 
 ## 6.3.2 - 2019-07-01
 

--- a/packages/thumbprint-react/CHANGELOG.md
+++ b/packages/thumbprint-react/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 -   [Patch] Update `ConditionalPortal` to explicitly allow and handle null contents. (#357)
 -   [Patch] Update description of Avatar prop.
--   [Minor] `Image` no longer fades in by default, added `fadeIn` prop if that behavior is desired. `ServiceCardImage` and `Avatar`, which use `Image` under the hood, also no longer fade in by default. (#368)
+-   [Minor] Remove fade-in from `Image`. (#368)
 
 ## 6.3.2 - 2019-07-01
 

--- a/packages/thumbprint-react/components/Avatar/__snapshots__/test.jsx.snap
+++ b/packages/thumbprint-react/components/Avatar/__snapshots__/test.jsx.snap
@@ -19,6 +19,7 @@ exports[`EntityAvatar renders an image when the user has one 1`] = `
     <Image
       alt=""
       className="squareAvatar"
+      fadeIn={false}
       height="48px"
       objectFit="cover"
       objectPosition="center"
@@ -30,7 +31,7 @@ exports[`EntityAvatar renders an image when the user has one 1`] = `
       >
         <img
           alt=""
-          className="image imageLoading"
+          className="image"
           height="48px"
           onError={[Function]}
           onLoad={[Function]}
@@ -105,6 +106,7 @@ exports[`adds the \`fullName\` as \`alt\` text when image is provided 1`] = `
     <Image
       alt="Avatar for Duck Goose"
       className="circleAvatar"
+      fadeIn={false}
       height="48px"
       objectFit="cover"
       objectPosition="center"
@@ -118,7 +120,7 @@ exports[`adds the \`fullName\` as \`alt\` text when image is provided 1`] = `
       >
         <img
           alt="Avatar for Duck Goose"
-          className="image imageLoading"
+          className="image"
           height="48px"
           onError={[Function]}
           onLoad={[Function]}
@@ -192,6 +194,7 @@ exports[`adds the \`fullName\` as \`title\` text 2`] = `
     <Image
       alt="Avatar for Duck Goose"
       className="circleAvatar"
+      fadeIn={false}
       height="48px"
       objectFit="cover"
       objectPosition="center"
@@ -205,7 +208,7 @@ exports[`adds the \`fullName\` as \`title\` text 2`] = `
       >
         <img
           alt="Avatar for Duck Goose"
-          className="image imageLoading"
+          className="image"
           height="48px"
           onError={[Function]}
           onLoad={[Function]}
@@ -692,6 +695,7 @@ exports[`renders an image when the user has one 1`] = `
     <Image
       alt=""
       className="circleAvatar"
+      fadeIn={false}
       height="48px"
       objectFit="cover"
       objectPosition="center"
@@ -703,7 +707,7 @@ exports[`renders an image when the user has one 1`] = `
       >
         <img
           alt=""
-          className="image imageLoading"
+          className="image"
           height="48px"
           onError={[Function]}
           onLoad={[Function]}

--- a/packages/thumbprint-react/components/Avatar/__snapshots__/test.jsx.snap
+++ b/packages/thumbprint-react/components/Avatar/__snapshots__/test.jsx.snap
@@ -19,7 +19,6 @@ exports[`EntityAvatar renders an image when the user has one 1`] = `
     <Image
       alt=""
       className="squareAvatar"
-      fadeIn={false}
       height="48px"
       objectFit="cover"
       objectPosition="center"
@@ -106,7 +105,6 @@ exports[`adds the \`fullName\` as \`alt\` text when image is provided 1`] = `
     <Image
       alt="Avatar for Duck Goose"
       className="circleAvatar"
-      fadeIn={false}
       height="48px"
       objectFit="cover"
       objectPosition="center"
@@ -194,7 +192,6 @@ exports[`adds the \`fullName\` as \`title\` text 2`] = `
     <Image
       alt="Avatar for Duck Goose"
       className="circleAvatar"
-      fadeIn={false}
       height="48px"
       objectFit="cover"
       objectPosition="center"
@@ -695,7 +692,6 @@ exports[`renders an image when the user has one 1`] = `
     <Image
       alt=""
       className="circleAvatar"
-      fadeIn={false}
       height="48px"
       objectFit="cover"
       objectPosition="center"

--- a/packages/thumbprint-react/components/Avatar/__snapshots__/test.jsx.snap
+++ b/packages/thumbprint-react/components/Avatar/__snapshots__/test.jsx.snap
@@ -31,7 +31,7 @@ exports[`EntityAvatar renders an image when the user has one 1`] = `
       >
         <img
           alt=""
-          className="image"
+          className="imageStart"
           height="48px"
           onError={[Function]}
           onLoad={[Function]}
@@ -120,7 +120,7 @@ exports[`adds the \`fullName\` as \`alt\` text when image is provided 1`] = `
       >
         <img
           alt="Avatar for Duck Goose"
-          className="image"
+          className="imageStart"
           height="48px"
           onError={[Function]}
           onLoad={[Function]}
@@ -208,7 +208,7 @@ exports[`adds the \`fullName\` as \`title\` text 2`] = `
       >
         <img
           alt="Avatar for Duck Goose"
-          className="image"
+          className="imageStart"
           height="48px"
           onError={[Function]}
           onLoad={[Function]}
@@ -707,7 +707,7 @@ exports[`renders an image when the user has one 1`] = `
       >
         <img
           alt=""
-          className="image"
+          className="imageStart"
           height="48px"
           onError={[Function]}
           onLoad={[Function]}

--- a/packages/thumbprint-react/components/Image/index.jsx
+++ b/packages/thumbprint-react/components/Image/index.jsx
@@ -139,7 +139,7 @@ const Image = forwardRef((props, outerRef) => {
 
         aspectRatioBoxProps.style = {
             paddingTop: `${(h / w) * 100}%`,
-            overflow: 'hidden', // Prevents alt text from taking up space before `src` is populated
+            overflow: 'hidden', // Prevents alt text fvsrom taking up space before `src` is populated
             height: 0,
         };
     }
@@ -218,13 +218,12 @@ const Image = forwardRef((props, outerRef) => {
                         setIsError(true);
                     }}
                     className={classNames({
-                        [styles.image]: true,
-                        // Sets opacity to 0
-                        [styles.imageFadeInStart]: fadeIn,
-                        // Sets opacity to 1 with short transition
-                        [styles.imageFadeInEnd]: fadeIn && isLoaded,
-                        // If fadeIn is true and there's an loading error set opacity to 1.
-                        [styles.imageError]: fadeIn && isError,
+                        // Opacity to 0, prevents flash of alt text when `height` prop used
+                        [styles.imageStart]: true,
+                        // Fade in transition if fadeIn `prop` prop used
+                        [styles.imageFadeIn]: fadeIn,
+                        // Opacity to 1 to reveal image or show alt text on error
+                        [styles.imageEnd]: isLoaded || isError,
                     })}
                 />
             </picture>

--- a/packages/thumbprint-react/components/Image/index.jsx
+++ b/packages/thumbprint-react/components/Image/index.jsx
@@ -15,7 +15,8 @@ import styles from './index.module.scss';
 // based on the containerAspectRatio.
 // 2. The "sizes" attr is calculated on initial render to determine width of image.
 // 3. When lazyload is triggered the src and scrSet props are populated based on the sizes value.
-// 4. The image onLoad event removes padding-top placholder and fades in the image.
+// 4. The image is set to opacity:0 to start to prevent flash of alt text
+// 5. The image onLoad and onError events remove padding-top placholder and sets opacity to 1.
 // --------------------------------------------------------------------------------------------
 
 const Image = forwardRef((props, outerRef) => {
@@ -28,7 +29,6 @@ const Image = forwardRef((props, outerRef) => {
         objectPosition,
         alt,
         className,
-        fadeIn,
         ...rest
     } = props;
 
@@ -220,8 +220,6 @@ const Image = forwardRef((props, outerRef) => {
                     className={classNames({
                         // Opacity to 0, prevents flash of alt text when `height` prop used
                         [styles.imageStart]: true,
-                        // Fade in transition if fadeIn `prop` prop used
-                        [styles.imageFadeIn]: fadeIn,
                         // Opacity to 1 to reveal image or show alt text on error
                         [styles.imageEnd]: isLoaded || isError,
                     })}
@@ -273,10 +271,6 @@ Image.propTypes = {
      * `object-position` CSS property. It is only useful if `height` is used to "crop" the image.
      */
     objectPosition: PropTypes.oneOf(['top', 'center', 'bottom', 'left', 'right']),
-    /**
-     * Fades the image in onload using opacity.
-     */
-    fadeIn: PropTypes.bool,
 };
 
 Image.defaultProps = {
@@ -286,7 +280,6 @@ Image.defaultProps = {
     containerAspectRatio: undefined,
     objectFit: 'cover',
     objectPosition: 'center',
-    fadeIn: false,
 };
 
 // Needed because of the `forwardRef`.

--- a/packages/thumbprint-react/components/Image/index.jsx
+++ b/packages/thumbprint-react/components/Image/index.jsx
@@ -28,6 +28,7 @@ const Image = forwardRef((props, outerRef) => {
         objectPosition,
         alt,
         className,
+        fadeIn,
         ...rest
     } = props;
 
@@ -210,8 +211,6 @@ const Image = forwardRef((props, outerRef) => {
                         ...(shouldObjectFit ? objectFitProps.style : {}),
                         ...(isLoaded || isError ? {} : aspectRatioBoxProps.style),
                     }}
-                    // Once loaded we remove the placeholder and add a class to transition the
-                    // opacity from 0 to 1.
                     onLoad={() => {
                         setIsLoaded(true);
                     }}
@@ -220,9 +219,12 @@ const Image = forwardRef((props, outerRef) => {
                     }}
                     className={classNames({
                         [styles.image]: true,
-                        [styles.imageLoading]: true,
-                        [styles.imageLoaded]: isLoaded,
-                        [styles.imageError]: isError,
+                        // Sets opacity to 0
+                        [styles.imageFadeInStart]: fadeIn,
+                        // Sets opacity to 1 with short transition
+                        [styles.imageFadeInEnd]: fadeIn && isLoaded,
+                        // If fadeIn is true and there's an loading error set opacity to 1.
+                        [styles.imageError]: fadeIn && isError,
                     })}
                 />
             </picture>
@@ -272,6 +274,10 @@ Image.propTypes = {
      * `object-position` CSS property. It is only useful if `height` is used to "crop" the image.
      */
     objectPosition: PropTypes.oneOf(['top', 'center', 'bottom', 'left', 'right']),
+    /**
+     * Fades the image in onload using opacity.
+     */
+    fadeIn: PropTypes.bool,
 };
 
 Image.defaultProps = {
@@ -281,6 +287,7 @@ Image.defaultProps = {
     containerAspectRatio: undefined,
     objectFit: 'cover',
     objectPosition: 'center',
+    fadeIn: false,
 };
 
 // Needed because of the `forwardRef`.

--- a/packages/thumbprint-react/components/Image/index.jsx
+++ b/packages/thumbprint-react/components/Image/index.jsx
@@ -139,7 +139,7 @@ const Image = forwardRef((props, outerRef) => {
 
         aspectRatioBoxProps.style = {
             paddingTop: `${(h / w) * 100}%`,
-            overflow: 'hidden', // Prevents alt text fvsrom taking up space before `src` is populated
+            overflow: 'hidden', // Prevents alt text from taking up space before `src` is populated
             height: 0,
         };
     }

--- a/packages/thumbprint-react/components/Image/index.module.scss
+++ b/packages/thumbprint-react/components/Image/index.module.scss
@@ -1,22 +1,18 @@
-.image,
 .picture {
     display: block;
     width: 100%;
-}
-
-.picture {
     overflow: hidden;
 }
 
-.imageFadeInStart {
+.imageStart {
+    width: 100%;
     opacity: 0;
 }
 
-.imageFadeInEnd {
-    opacity: 1;
+.imageFadeIn {
     transition: opacity 300ms;
 }
 
-.imageError {
+.imageEnd {
     opacity: 1;
 }

--- a/packages/thumbprint-react/components/Image/index.module.scss
+++ b/packages/thumbprint-react/components/Image/index.module.scss
@@ -8,11 +8,11 @@
     overflow: hidden;
 }
 
-.imageLoading {
+.imageFadeInStart {
     opacity: 0;
 }
 
-.imageLoaded {
+.imageFadeInEnd {
     opacity: 1;
     transition: opacity 300ms;
 }

--- a/packages/thumbprint-react/components/Image/index.module.scss
+++ b/packages/thumbprint-react/components/Image/index.module.scss
@@ -10,10 +10,6 @@
     opacity: 0;
 }
 
-.imageFadeIn {
-    transition: opacity 300ms;
-}
-
 .imageEnd {
     opacity: 1;
 }

--- a/packages/thumbprint-react/components/Image/index.module.scss
+++ b/packages/thumbprint-react/components/Image/index.module.scss
@@ -5,6 +5,7 @@
 }
 
 .imageStart {
+    display: block;
     width: 100%;
     opacity: 0;
 }

--- a/packages/thumbprint-react/components/ServiceCard/__snapshots__/test.jsx.snap
+++ b/packages/thumbprint-react/components/ServiceCard/__snapshots__/test.jsx.snap
@@ -77,7 +77,6 @@ exports[`ServiceCardImage render works 1`] = `
     alt="duck duck goose"
     className="image"
     containerAspectRatio={1.6}
-    fadeIn={false}
     objectFit="cover"
     objectPosition="center"
     sources={Array []}

--- a/packages/thumbprint-react/components/ServiceCard/__snapshots__/test.jsx.snap
+++ b/packages/thumbprint-react/components/ServiceCard/__snapshots__/test.jsx.snap
@@ -88,7 +88,7 @@ exports[`ServiceCardImage render works 1`] = `
     >
       <img
         alt="duck duck goose"
-        className="image"
+        className="imageStart"
         onError={[Function]}
         onLoad={[Function]}
         sizes="0px"

--- a/packages/thumbprint-react/components/ServiceCard/__snapshots__/test.jsx.snap
+++ b/packages/thumbprint-react/components/ServiceCard/__snapshots__/test.jsx.snap
@@ -77,6 +77,7 @@ exports[`ServiceCardImage render works 1`] = `
     alt="duck duck goose"
     className="image"
     containerAspectRatio={1.6}
+    fadeIn={false}
     objectFit="cover"
     objectPosition="center"
     sources={Array []}
@@ -87,7 +88,7 @@ exports[`ServiceCardImage render works 1`] = `
     >
       <img
         alt="duck duck goose"
-        className="image imageLoading"
+        className="image"
         onError={[Function]}
         onLoad={[Function]}
         sizes="0px"

--- a/www/src/pages/components/image/react/index.mdx
+++ b/www/src/pages/components/image/react/index.mdx
@@ -80,6 +80,19 @@ The image component accepts `style` and `className` props. This example uses bot
 </div>
 ```
 
+## Fade In
+
+This example uses the `fadeIn` prop to fade-in the image over 300ms using opacity.
+
+```jsx
+<Image
+    src="https://d1vg1gqh4nkuns.cloudfront.net/i/327896627728072894/width/1024.jpeg"
+    alt="Grass with concrete steps"
+    containerAspectRatio={400 / 250}
+    fadeIn
+/>
+```
+
 ## Cropped images with `height`
 
 This example uses the `height` prop to "crop" the image. By default, the cropped image is vertically centered with `object-position: center center`.

--- a/www/src/pages/components/image/react/index.mdx
+++ b/www/src/pages/components/image/react/index.mdx
@@ -80,19 +80,6 @@ The image component accepts `style` and `className` props. This example uses bot
 </div>
 ```
 
-## Fade In
-
-This example uses the `fadeIn` prop to fade-in the image over 300ms using opacity.
-
-```jsx
-<Image
-    src="https://d1vg1gqh4nkuns.cloudfront.net/i/327896627728072894/width/1024.jpeg"
-    alt="Grass with concrete steps"
-    containerAspectRatio={400 / 250}
-    fadeIn
-/>
-```
-
 ## Cropped images with `height`
 
 This example uses the `height` prop to "crop" the image. By default, the cropped image is vertically centered with `object-position: center center`.


### PR DESCRIPTION
Removes fade-in.

- [x] Check `Image`, `Avatar`, and `ServiceCard` deploy in FF, Safari, Chrome, Edge 18.

Fixes #368 