### PR TITLE
Standardize not wrapping Markdown with prettier

### DIFF
--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -2,3 +2,4 @@ printWidth: 100
 tabWidth: 4
 trailingComma: all
 singleQuote: true
+proseWrap: never

--- a/www/src/pages/atomic/usage.mdx
+++ b/www/src/pages/atomic/usage.mdx
@@ -112,8 +112,7 @@ If the Atomic class you’d like is not available please write the custom CSS in
 
 ## Limitations
 
-Although Atomic can significantly reduce the amount of CSS you write it won’t cover every use
-case. At times you’ll have to use other approaches.
+Although Atomic can significantly reduce the amount of CSS you write it won’t cover every use case. At times you’ll have to use other approaches.
 
 -   **Custom values** Layouts will sometimes require non-standardized positioning, heights, or widths that aren’t available in the Atomic library. Hardcode them into your CSS with a comment.
 -   **`last-child` and `first-child` selectors** Atomic isn’t well-suited to handle pseudo classes. For example, if you need `margin-bottom` on all objects but the last one, either:

--- a/www/src/pages/components/button-row/react/index.mdx
+++ b/www/src/pages/components/button-row/react/index.mdx
@@ -41,9 +41,7 @@ import { ComponentHeader, ComponentFooter } from 'components/thumbprint-componen
 
 Best used with `"full-below-small"` on the children.
 
-Note: this reverses the order of the buttons on small screens as well, per our
-design guidelines which require primary action buttons to be on the right of a
-row, but on top when stacked.
+Note: this reverses the order of the buttons on small screens as well, per our design guidelines which require primary action buttons to be on the right of a row, but on top when stacked.
 
 ```jsx
 <ButtonRow isStackedBelowSmall justify="right">

--- a/www/src/pages/components/checkbox/react/index.mdx
+++ b/www/src/pages/components/checkbox/react/index.mdx
@@ -90,8 +90,7 @@ function CheckboxExample() {
 
 ## Disabled checkboxes
 
-The `isDisabled` prop visually and functionally disabled the radio button.
-It also visually disables the related label.
+The `isDisabled` prop visually and functionally disabled the radio button. It also visually disables the related label.
 
 ```jsx
 <React.Fragment>
@@ -111,8 +110,7 @@ It also visually disables the related label.
 
 The `hasError` prop can be used to visually represent an error.
 
-This prop only changes the checkbox’s color.
-It should be used alongside an error message that helps users advance through the form.
+This prop only changes the checkbox’s color. It should be used alongside an error message that helps users advance through the form.
 
 ```jsx
 function CheckboxExample() {
@@ -127,12 +125,9 @@ function CheckboxExample() {
 
 ## Multi-column content
 
-It’s possible to provide complex UIs to the `children` prop.
-Clicking on the content will select the related checkbox.
+It’s possible to provide complex UIs to the `children` prop. Clicking on the content will select the related checkbox.
 
-This example puts the label content within `children`.
-It’s also possible to not provide `children` as `undefined` and use a custom `label` instead.
-In that case, you must use `Checkbox`’s `id` prop.
+This example puts the label content within `children`. It’s also possible to not provide `children` as `undefined` and use a custom `label` instead. In that case, you must use `Checkbox`’s `id` prop.
 
 ```jsx
 function CheckboxExample() {
@@ -156,8 +151,7 @@ function CheckboxExample() {
 }
 ```
 
-Checkbox input by default is vertically center-aligned with `children`.
-If `children` prop spans over multiple lines and you want it to align at the top, it is possible to provide `checkboxVerticalAlign` prop as `top`.
+Checkbox input by default is vertically center-aligned with `children`. If `children` prop spans over multiple lines and you want it to align at the top, it is possible to provide `checkboxVerticalAlign` prop as `top`.
 
 ```jsx
 function CheckboxExample() {

--- a/www/src/pages/components/input/react/index.mdx
+++ b/www/src/pages/components/input/react/index.mdx
@@ -236,8 +236,7 @@ class InputExample extends React.Component {
 
 ## Date inputs
 
-Because of browser UI inconsistencies we do not use <code>type='date'</code> and instead suggest
-using a separate text <code>input</code> or <code>select</code> elements to gather this information from users.
+Because of browser UI inconsistencies we do not use <code>type='date'</code> and instead suggest using a separate text <code>input</code> or <code>select</code> elements to gather this information from users.
 
 <ComponentFooter data={props.data} />
 

--- a/www/src/pages/components/input/scss/index.mdx
+++ b/www/src/pages/components/input/scss/index.mdx
@@ -102,8 +102,7 @@ You can use the `tp-input-icon` classes to include a [Thumbprint Icon](/icons/) 
 
 ## Date inputs
 
-Because of browser UI inconsistencies we do not use <code>type='date'</code> and instead suggest
-using a separate text <code>input</code> or <code>select</code> elements to gather this information from users.
+Because of browser UI inconsistencies we do not use <code>type='date'</code> and instead suggest using a separate text <code>input</code> or <code>select</code> elements to gather this information from users.
 
 <ComponentFooter data={props.data} />
 

--- a/www/src/pages/components/modal-curtain/react/index.mdx
+++ b/www/src/pages/components/modal-curtain/react/index.mdx
@@ -11,24 +11,19 @@ import { ComponentHeader, ComponentFooter } from 'components/thumbprint-componen
 
 ## Examples
 
-The `ModalCurtain` component makes it easy to create an accessible overlay that contains content and covers the page.
-It contains a few powerful features:
+The `ModalCurtain` component makes it easy to create an accessible overlay that contains content and covers the page. It contains a few powerful features:
 
--   **Focus trap:** Move the browser's focus to the first interactive element within the `children`.
-    Trap the focus within the `ModalCurtain` while it is open, preventing users from accidentally tabbing to the page underneath.
+-   **Focus trap:** Move the browser's focus to the first interactive element within the `children`. Trap the focus within the `ModalCurtain` while it is open, preventing users from accidentally tabbing to the page underneath.
 -   **Scroll lock:** Prevent the page from scrolling while the `ModalCurtain` is open.
--   **Append to the body tag:** Move the HTML to end of the DOM, right before the `</body>` tag.
-    This greatly decreases the chance of running into z-index issues.
+-   **Append to the body tag:** Move the HTML to end of the DOM, right before the `</body>` tag. This greatly decreases the chance of running into z-index issues.
 -   **Listen for Esc key press:** Run a function to close the `ModalCurtain` if the user presses Esc.
 -   **Close on `ModalCurtain` click:** Make it easy to close the modal if the `ModalCurtain` is clicked on.
 
-The `ModalCurtain` component CSS handles positioning, overflow, z-index, visibility, and opacity.
-It does not include background colors, padding, transitions, or other opinionated styles since the component was designed to be versatile.
+The `ModalCurtain` component CSS handles positioning, overflow, z-index, visibility, and opacity. It does not include background colors, padding, transitions, or other opinionated styles since the component was designed to be versatile.
 
 ### `ModalCurtain` with a basic modal
 
-This example contains a `ModalCurtain` with a basic modal and no transition.
-Because there is no transition, the `stage` prop only cycles between `entered` and `exited`.
+This example contains a `ModalCurtain` with a basic modal and no transition. Because there is no transition, the `stage` prop only cycles between `entered` and `exited`.
 
 ```jsx
 function ModalCurtainDemo() {
@@ -74,8 +69,7 @@ function ModalCurtainDemo() {
 
 ### `ModalCurtain` with a full screen takeover
 
-The `ModalCurtain` component works well for full-screen takeovers.
-This example doesn't use `curtainOnClick` since we don't want to close the curtain when clicking on the backdrop.
+The `ModalCurtain` component works well for full-screen takeovers. This example doesn't use `curtainOnClick` since we don't want to close the curtain when clicking on the backdrop.
 
 ```jsx
 function ModalCurtainDemo() {

--- a/www/src/pages/components/modal-default/react/index.mdx
+++ b/www/src/pages/components/modal-default/react/index.mdx
@@ -422,8 +422,7 @@ function ModalDefaultDemoNarrow() {
 
 ### Full bleed modal
 
-You can use the `ModalDefaultContentFullBleed` component to create a section of modal content that visually reaches the edge of the modal.
-This is useful for setting your own background color or section borders, for example.
+You can use the `ModalDefaultContentFullBleed` component to create a section of modal content that visually reaches the edge of the modal. This is useful for setting your own background color or section borders, for example.
 
 <Alert type="warning" title="Warning" className="mt5">
     This component provides the same amount of padding as the modal itself, so it can't be used to

--- a/www/src/pages/components/popover/usage/index.mdx
+++ b/www/src/pages/components/popover/usage/index.mdx
@@ -19,8 +19,7 @@ Note: If the popover is a part of a series, the CTA copy should reflect this by 
 
 ## As a series
 
-Popovers are best used for tutorials and walkthroughs and thus need to be strung together as a series of tips.
-To best achieve this, make sure the developer is aware of the steps in the flow, and write content that makes it clear that there is a progression in the series.
+Popovers are best used for tutorials and walkthroughs and thus need to be strung together as a series of tips. To best achieve this, make sure the developer is aware of the steps in the flow, and write content that makes it clear that there is a progression in the series.
 
 If a back button is needed, use the link variant to include a back button for the series.
 
@@ -28,8 +27,7 @@ If a back button is needed, use the link variant to include a back button for th
 
 ## Behaviour and Nubbin Positioning
 
-Popovers are triggered during onboarding, any first time user experience, or an announcement of a new feature.
-The nubbin of the popover should be positioned to point to the feature/area the popover is referencing for best context.
+Popovers are triggered during onboarding, any first time user experience, or an announcement of a new feature. The nubbin of the popover should be positioned to point to the feature/area the popover is referencing for best context.
 
 The nubbin can be placed at the start, middle, or end of each of the 4 sides of the popover.
 

--- a/www/src/pages/components/radio/react/index.mdx
+++ b/www/src/pages/components/radio/react/index.mdx
@@ -74,8 +74,7 @@ function RadioExample() {
 
 ## Disabled radio buttons
 
-The `isDisabled` prop visually and functionally disabled the radio button.
-It also visually disables the related label.
+The `isDisabled` prop visually and functionally disabled the radio button. It also visually disables the related label.
 
 ```jsx
 <React.Fragment>
@@ -107,8 +106,7 @@ It also visually disables the related label.
 
 The `hasError` prop can be used to visually represent an error.
 
-This prop only changes the radio button’s color.
-It should be used alongside an error message that helps users advance through the form.
+This prop only changes the radio button’s color. It should be used alongside an error message that helps users advance through the form.
 
 ```jsx
 function RadioExample() {
@@ -124,12 +122,9 @@ function RadioExample() {
 
 ## Multi-column content
 
-It’s possible to provide complex UIs to the `children` prop.
-Clicking on the content will select the related radio button.
+It’s possible to provide complex UIs to the `children` prop. Clicking on the content will select the related radio button.
 
-This example puts the label content within `children`.
-It’s also possible to not provide `children` as `undefined` and use a custom `label` instead.
-In that case, you must use `Radio`’s `id` prop.
+This example puts the label content within `children`. It’s also possible to not provide `children` as `undefined` and use a custom `label` instead. In that case, you must use `Radio`’s `id` prop.
 
 ```jsx
 function RadioExample() {
@@ -158,8 +153,7 @@ function RadioExample() {
 }
 ```
 
-Radio input by default is vertically center-aligned with `children`.
-If `children` prop spans over multiple lines and you want it to align at the top, it is possible to provide `radioVerticalAlign` prop as `top`.
+Radio input by default is vertically center-aligned with `children`. If `children` prop spans over multiple lines and you want it to align at the top, it is possible to provide `radioVerticalAlign` prop as `top`.
 
 ```jsx
 function RadioExample() {

--- a/www/src/pages/components/select/react/index.mdx
+++ b/www/src/pages/components/select/react/index.mdx
@@ -10,11 +10,9 @@ import { ComponentHeader, ComponentFooter } from 'components/thumbprint-componen
 
 ## Select dropdown with state management
 
-`Select` is a controlled component. This means that the selected `option`, if any, must be provided as the `value` prop.
-The `onChange` function updates the `value` when the user selects a new option.
+`Select` is a controlled component. This means that the selected `option`, if any, must be provided as the `value` prop. The `onChange` function updates the `value` when the user selects a new option.
 
-In this example, notice how `value` is stored within a `React.useState` object.
-The `onChange` function updates the state when the user selects a new option.
+In this example, notice how `value` is stored within a `React.useState` object. The `onChange` function updates the state when the user selects a new option.
 
 ```jsx
 function SelectExample() {
@@ -80,8 +78,7 @@ function SelectExample() {
 
 ## Widths
 
-By default, the `Select` component renders as an `inline-block` element.
-Its width is determined by the `option` with the longest text.
+By default, the `Select` component renders as an `inline-block` element. Its width is determined by the `option` with the longest text.
 
 The `isFullWidth` prop can be used to set the width to 100%.
 
@@ -131,8 +128,7 @@ function SelectExample() {
 
 The `hasError` prop can be used to visually represent an error.
 
-This prop only changes the select dropdown’s color.
-It should be used alongside an error message that helps users advance through the form.
+This prop only changes the select dropdown’s color. It should be used alongside an error message that helps users advance through the form.
 
 ```jsx
 function SelectExample() {

--- a/www/src/pages/components/textarea/react/index.mdx
+++ b/www/src/pages/components/textarea/react/index.mdx
@@ -10,11 +10,9 @@ import { ComponentHeader, ComponentFooter } from 'components/thumbprint-componen
 
 ## Basic textarea
 
-`Textarea` is a controlled component.
-This means that the visible text will always match the contents of the `value` prop.
+`Textarea` is a controlled component. This means that the visible text will always match the contents of the `value` prop.
 
-In this example, notice how `value` is stored within `this.state`.
-The `onChange` function will set the new `value` when the user enters or removes a character in the textarea.
+In this example, notice how `value` is stored within `this.state`. The `onChange` function will set the new `value` when the user enters or removes a character in the textarea.
 
 ```jsx
 function TextareaExample() {

--- a/www/src/pages/components/tooltip/usage/index.mdx
+++ b/www/src/pages/components/tooltip/usage/index.mdx
@@ -15,8 +15,7 @@ import { Grid, GridColumn } from '@thumbtack/thumbprint-react';
 
 Tooltips are an informational UI tool that briefly explain the function of a user interface element. They can be triggered when users hover, focus, tap, or click.
 
-The default tooltip has a black container and contains basic information explaining a
-feature or part of the UI.
+The default tooltip has a black container and contains basic information explaining a feature or part of the UI.
 
 ### Common features
 
@@ -45,12 +44,9 @@ The animation duration is `150ms` easing on entrance and exit.
 
 ## Behavior and positioning
 
-Tooltips can be positioned on the top or the bottom of a trigger, and with a slight
-animation originating from the trigger.
+Tooltips can be positioned on the top or the bottom of a trigger, and with a slight animation originating from the trigger.
 
-In the event that a tooltip doesn’t have enough space to be centered, it will be
-automatically positioned using the “best-placement” attribute. It will default on top
-or bottom and move left/right/down/up depending on the available space.
+In the event that a tooltip doesn’t have enough space to be centered, it will be automatically positioned using the “best-placement” attribute. It will default on top or bottom and move left/right/down/up depending on the available space.
 
 <div className="flex flex-wrap mt5">
     <div className="mb3 mr3" style={{ maxWidth: '232px' }}>
@@ -68,8 +64,7 @@ or bottom and move left/right/down/up depending on the available space.
 
 In addition to their positioning, tooltips come in a light and dark theme.
 
-Note: The tooltip theme should be opposite whatever background it is on for maximum
-readability.
+Note: The tooltip theme should be opposite whatever background it is on for maximum readability.
 
 <div className="flex flex-wrap mt5">
     <div className="mb3 mr3" style={{ maxWidth: '154px' }}>

--- a/www/src/pages/guide/product/spacers/index.mdx
+++ b/www/src/pages/guide/product/spacers/index.mdx
@@ -10,12 +10,9 @@ Good spacing systems are based on increments that are visually distinguishable a
 
 ## 16px = base increment
 
-Our spacing system is built on a base increment of 16px, with factors of 4px and 8px.
-The base of 16px also acts as a default spacer, as it is the most widely used spacing
-increment.
+Our spacing system is built on a base increment of 16px, with factors of 4px and 8px. The base of 16px also acts as a default spacer, as it is the most widely used spacing increment.
 
-Multiples of 16 make up the upper increments of our spacing system. Please stick to
-these increments to maintain consistency.
+Multiples of 16 make up the upper increments of our spacing system. Please stick to these increments to maintain consistency.
 
 <div className="flex items-center mb2">
     <div className="w1 b">1</div>

--- a/www/src/pages/icons/index.mdx
+++ b/www/src/pages/icons/index.mdx
@@ -11,8 +11,7 @@ import { Img } from 'components/mdx';
 
 <Img src="./icon-hero.png" className="db" />
 
-For legal reasons we require authentication to download Thumbprint icons. If you’re not
-already logged into Okta you’ll be asked to enter your credentials before you proceed.
+For legal reasons we require authentication to download Thumbprint icons. If you’re not already logged into Okta you’ll be asked to enter your credentials before you proceed.
 
 <ThemedLink to="https://icons.thumbprint.design/" icon={<ContentModifierLockedSmall />}>
     Open Thumbprint Icons


### PR DESCRIPTION
We decided not to wrap it primarily so we can continue editing MD/MDX through the GitHub UI without needing to manually wrap.

***
I'll wait to merge this one until @lavelle merges his in progress PRs so that he doesn't need to re-run prettier on them.