### PR TITLE
Fix markdown in Input React documentation

### DIFF
--- a/www/src/pages/components/input/react/index.mdx
+++ b/www/src/pages/components/input/react/index.mdx
@@ -236,8 +236,8 @@ class InputExample extends React.Component {
 
 ## Date inputs
 
-Because of browser UI inconsistencies we do not use <code>type='date'</code> and instead suggest
-using a separate text <code>input</code> or <code>select</code> elements to gather this information from users.
+Because of browser UI inconsistencies we do not use `type='date'` and instead suggest
+using a separate text `input` or `select` elements to gather this information from users.
 
 <ComponentFooter data={props.data} />
 


### PR DESCRIPTION
It is currently rendering like this:

<img width="659" alt="image" src="https://user-images.githubusercontent.com/916038/61558008-aaa01400-aa1a-11e9-9040-9d2c1868681e.png">
