### PR TITLE
Add react version of the horizontal rule

### DIFF
--- a/packages/thumbprint-react/components/HorizontalRule/index.jsx
+++ b/packages/thumbprint-react/components/HorizontalRule/index.jsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import styles from './index.module.scss';
+
+const propTypes = {
+    /**
+     * Renders the horizontal rule with the thumbtack styles.
+     */
+    lineStyle: PropTypes.oneOf(['original', 'dotted', 'dashed']),
+    color: PropTypes.oneOf(['gray', 'gray-300']),
+};
+
+const defaultProps = {
+    lineStyle: 'original',
+    color: 'gray',
+};
+
+export default function HorizontalRule({ lineStyle, color }) {
+    return (
+        <hr
+            className={classNames({
+                [styles.root]: true,
+                [styles.gray300]: color === 'gray-300',
+                [styles.dashed]: lineStyle === 'dashed',
+                [styles.dotted]: lineStyle === 'dotted',
+            })}
+        />
+    );
+}
+
+HorizontalRule.propTypes = propTypes;
+HorizontalRule.defaultProps = defaultProps;

--- a/packages/thumbprint-react/components/HorizontalRule/index.module.scss
+++ b/packages/thumbprint-react/components/HorizontalRule/index.module.scss
@@ -1,0 +1,21 @@
+@import '~@thumbtack/thumbprint-tokens/dist/scss/_index';
+
+.root {
+    border: 0;
+    height: 0;
+    border-top: 1px solid $tp-color__gray;
+    margin-top: $tp-space__2 - 1px;
+    margin-bottom: $tp-space__2;
+}
+
+.dotted {
+    border-top-style: dotted;
+}
+
+.dashed {
+    border-top-style: dashed;
+}
+
+.gray300 {
+    border-top-color: $tp_color__gray-300;
+}

--- a/packages/thumbprint-react/components/HorizontalRule/test.jsx
+++ b/packages/thumbprint-react/components/HorizontalRule/test.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import HorizontalRule from './index';
+
+test('renders default horizontal rule', () => {
+    const wrapper = mount(<HorizontalRule />);
+    expect(wrapper).toMatchSnapshot();
+});
+
+test('renders dotted horizontal rule', () => {
+    const wrapper = mount(<HorizontalRule lineStyle="dashed" />);
+    expect(wrapper).toMatchSnapshot();
+});
+
+test('renders black horizontal rule', () => {
+    const wrapper = mount(<HorizontalRule color="black" />);
+    expect(wrapper).toMatchSnapshot();
+});

--- a/packages/thumbprint-react/index.js
+++ b/packages/thumbprint-react/index.js
@@ -6,6 +6,7 @@ export { default as Carousel } from './components/Carousel/index.jsx';
 export { default as Checkbox } from './components/Checkbox/index.jsx';
 export { default as DatePicker } from './components/DatePicker/index.jsx';
 export { default as FormNote } from './components/FormNote/index.jsx';
+export { default as HorizontalRule } from './components/HorizontalRule/index.jsx';
 export { Grid, GridColumn } from './components/Grid/index.jsx';
 export { default as Image } from './components/Image/index.jsx';
 export { default as Input, InputIcon, InputClearButton } from './components/Input/index.jsx';

--- a/www/src/pages/components/horizontal-rule/react/index.mdx
+++ b/www/src/pages/components/horizontal-rule/react/index.mdx
@@ -1,0 +1,68 @@
+---
+title: Horizontal Rule
+description: Dividers that separate sections of content.
+---
+
+import { graphql } from 'gatsby';
+import { ComponentHeader, ComponentFooter } from 'components/thumbprint-components';
+
+<ComponentHeader data={props.data} />
+
+## Horizontal Rule Styles
+
+### Basic
+
+```jsx
+<React.Fragment>
+    <HorizontalRule />
+</React.Fragment>
+```
+
+### Dotted
+
+```jsx
+<React.Fragment>
+    <HorizontalRule lineStyle="dotted" />
+</React.Fragment>
+```
+
+### Dashed
+
+```jsx
+<React.Fragment>
+    <HorizontalRule lineStyle="dashed" />
+</React.Fragment>
+```
+
+### Gray-300
+
+```jsx
+<React.Fragment>
+    <HorizontalRule color="gray-300" />
+</React.Fragment>
+```
+
+<ComponentFooter data={props.data} />
+
+export const pageQuery = graphql`
+    {
+        # Get links to by path to display in the navbar.
+        platformNav: allSitePage(filter: { path: { glob: "/components/horizontal-rule/*/" } }) {
+            edges {
+                node {
+                    ...PlatformNavFragment
+                }
+            }
+        }
+        # Get package information by NPM package name.
+        packageTable: thumbprintComponent(name: { eq: "@thumbtack/thumbprint-react" }) {
+            ...PackageTableFragment
+        }
+        # Get component props by path to component file.
+        reactComponentProps: file(
+            relativePath: { eq: "thumbprint-react/components/HorizontalRule/index.jsx" }
+        ) {
+            ...ReactComponentPropsFragment
+        }
+    }
+`;


### PR DESCRIPTION
This allows for use of the horizontal rule without importing
the full tpui css.