### PR TITLE
Restore focus state on React radio inputs

### DIFF
--- a/packages/thumbprint-react/CHANGELOG.md
+++ b/packages/thumbprint-react/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+-   [Patch] Restore border color of focused `Radio` input.
+
 ## 7.1.0 - 2019-07-31
 
 ### Changed

--- a/packages/thumbprint-react/components/Radio/index.module.scss
+++ b/packages/thumbprint-react/components/Radio/index.module.scss
@@ -20,7 +20,7 @@
     width: 1px;
     height: 1px;
 
-    &:focus ~ .radio-image {
+    &:focus ~ .radioImage {
         box-shadow: 0 0 0px 4px $tp-color__gray-300;
     }
 }


### PR DESCRIPTION
A typo had been preventing the input focus ring from being shown and now works. This is the same style we have in the SCSS version.

![Screen Shot 2019-08-05 at 12 00 46 PM](https://user-images.githubusercontent.com/1171072/62490678-c9bed580-b77e-11e9-8e86-bfdb8fab0c52.png)

cc: @hsiaoman87 