### PR TITLE
Ignore tab in React examples code editor

### DIFF
--- a/www/src/components/mdx/code-block/react-code-block.jsx
+++ b/www/src/components/mdx/code-block/react-code-block.jsx
@@ -22,7 +22,7 @@ const ReactCodeBlock = props => {
             <LivePreview className={`${classes.preview} ${previewThemes[theme]}`} />
 
             <div className={classes.codeContainer}>
-                <LiveEditor className={classes.code} />
+                <LiveEditor className={classes.code} ignoreTabKey />
             </div>
 
             <pre>


### PR DESCRIPTION
Makes it easier to test tabbing behavior.