### PR TITLE
Fix bug in BaseCarousel caused by misuse of hooks

### DIFF
--- a/packages/thumbprint-react/CHANGELOG.md
+++ b/packages/thumbprint-react/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+-   [Patch] Fix a bug in `BaseCarousel` caused by previous refactor. (#427)
+
 ## 9.0.1 - 2019-08-13
 
 ### Changed

--- a/packages/thumbprint-react/components/Carousel/__snapshots__/test.jsx.snap
+++ b/packages/thumbprint-react/components/Carousel/__snapshots__/test.jsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`\`selectedIndex\` supports decimal \`selectedIndex\` values 1`] = `
+exports[`Carousel \`selectedIndex\` supports decimal \`selectedIndex\` values 1`] = `
 <Carousel
   onSelectedIndexChange={[Function]}
   selectedIndex={2.3}
@@ -104,134 +104,6 @@ exports[`\`selectedIndex\` supports decimal \`selectedIndex\` values 1`] = `
                   4
                 </div>
               </li>
-              <li
-                className="item"
-                key="4/.0"
-                style={
-                  Object {
-                    "order": 6,
-                    "paddingRight": "0px",
-                    "transform": "translateX(-800%)",
-                    "width": "100%",
-                  }
-                }
-              >
-                <div>
-                  1
-                </div>
-              </li>
-              <li
-                className="item"
-                key="5/.1"
-                style={
-                  Object {
-                    "order": 7,
-                    "paddingRight": "0px",
-                    "transform": "translateX(-800%)",
-                    "width": "100%",
-                  }
-                }
-              >
-                <div>
-                  2
-                </div>
-              </li>
-              <li
-                className="item"
-                key="6/.2"
-                style={
-                  Object {
-                    "order": 4,
-                    "paddingRight": "0px",
-                    "transform": "translateX(-800%)",
-                    "width": "100%",
-                  }
-                }
-              >
-                <div>
-                  3
-                </div>
-              </li>
-              <li
-                className="item"
-                key="7/.3"
-                style={
-                  Object {
-                    "order": 5,
-                    "paddingRight": "0px",
-                    "transform": "translateX(-800%)",
-                    "width": "100%",
-                  }
-                }
-              >
-                <div>
-                  4
-                </div>
-              </li>
-              <li
-                className="item"
-                key="4/.0"
-                style={
-                  Object {
-                    "order": 12,
-                    "paddingRight": "0px",
-                    "transform": "translateX(-400%)",
-                    "width": "100%",
-                  }
-                }
-              >
-                <div>
-                  1
-                </div>
-              </li>
-              <li
-                className="item"
-                key="6/.1"
-                style={
-                  Object {
-                    "order": 14,
-                    "paddingRight": "0px",
-                    "transform": "translateX(-400%)",
-                    "width": "100%",
-                  }
-                }
-              >
-                <div>
-                  2
-                </div>
-              </li>
-              <li
-                className="item"
-                key="8/.2"
-                style={
-                  Object {
-                    "order": 8,
-                    "paddingRight": "0px",
-                    "transform": "translateX(-400%)",
-                    "width": "100%",
-                  }
-                }
-              >
-                <div>
-                  3
-                </div>
-              </li>
-              <li
-                className="item"
-                key="10/.3"
-                style={
-                  Object {
-                    "order": 10,
-                    "paddingRight": "0px",
-                    "transform": "translateX(-400%)",
-                    "width": "100%",
-                  }
-                }
-              >
-                <div>
-                  4
-                </div>
-              </li>
             </ul>
           </div>
         </BaseCarousel>
@@ -241,7 +113,7 @@ exports[`\`selectedIndex\` supports decimal \`selectedIndex\` values 1`] = `
 </Carousel>
 `;
 
-exports[`\`selectedIndex\` supports negative \`selectedIndex\` 1`] = `
+exports[`Carousel \`selectedIndex\` supports negative \`selectedIndex\` 1`] = `
 <Carousel
   onSelectedIndexChange={[Function]}
   selectedIndex={-0.8}
@@ -345,134 +217,6 @@ exports[`\`selectedIndex\` supports negative \`selectedIndex\` 1`] = `
                   4
                 </div>
               </li>
-              <li
-                className="item"
-                key="4/.0"
-                style={
-                  Object {
-                    "order": 5,
-                    "paddingRight": "0px",
-                    "transform": "translateX(-800%)",
-                    "width": "100%",
-                  }
-                }
-              >
-                <div>
-                  1
-                </div>
-              </li>
-              <li
-                className="item"
-                key="5/.1"
-                style={
-                  Object {
-                    "order": 6,
-                    "paddingRight": "0px",
-                    "transform": "translateX(-800%)",
-                    "width": "100%",
-                  }
-                }
-              >
-                <div>
-                  2
-                </div>
-              </li>
-              <li
-                className="item"
-                key="6/.2"
-                style={
-                  Object {
-                    "order": 7,
-                    "paddingRight": "0px",
-                    "transform": "translateX(-800%)",
-                    "width": "100%",
-                  }
-                }
-              >
-                <div>
-                  3
-                </div>
-              </li>
-              <li
-                className="item"
-                key="7/.3"
-                style={
-                  Object {
-                    "order": 4,
-                    "paddingRight": "0px",
-                    "transform": "translateX(-800%)",
-                    "width": "100%",
-                  }
-                }
-              >
-                <div>
-                  4
-                </div>
-              </li>
-              <li
-                className="item"
-                key="4/.0"
-                style={
-                  Object {
-                    "order": 10,
-                    "paddingRight": "0px",
-                    "transform": "translateX(-400%)",
-                    "width": "100%",
-                  }
-                }
-              >
-                <div>
-                  1
-                </div>
-              </li>
-              <li
-                className="item"
-                key="6/.1"
-                style={
-                  Object {
-                    "order": 12,
-                    "paddingRight": "0px",
-                    "transform": "translateX(-400%)",
-                    "width": "100%",
-                  }
-                }
-              >
-                <div>
-                  2
-                </div>
-              </li>
-              <li
-                className="item"
-                key="8/.2"
-                style={
-                  Object {
-                    "order": 14,
-                    "paddingRight": "0px",
-                    "transform": "translateX(-400%)",
-                    "width": "100%",
-                  }
-                }
-              >
-                <div>
-                  3
-                </div>
-              </li>
-              <li
-                className="item"
-                key="10/.3"
-                style={
-                  Object {
-                    "order": 8,
-                    "paddingRight": "0px",
-                    "transform": "translateX(-400%)",
-                    "width": "100%",
-                  }
-                }
-              >
-                <div>
-                  4
-                </div>
-              </li>
             </ul>
           </div>
         </BaseCarousel>
@@ -482,7 +226,7 @@ exports[`\`selectedIndex\` supports negative \`selectedIndex\` 1`] = `
 </Carousel>
 `;
 
-exports[`\`spacing\` no spacing 1`] = `
+exports[`Carousel \`spacing\` no spacing 1`] = `
 <Carousel
   onSelectedIndexChange={[Function]}
   selectedIndex={0}
@@ -586,134 +330,6 @@ exports[`\`spacing\` no spacing 1`] = `
                   4
                 </div>
               </li>
-              <li
-                className="item"
-                key="4/.0"
-                style={
-                  Object {
-                    "order": 4,
-                    "paddingRight": "0px",
-                    "transform": "translateX(-800%)",
-                    "width": "100%",
-                  }
-                }
-              >
-                <div>
-                  1
-                </div>
-              </li>
-              <li
-                className="item"
-                key="5/.1"
-                style={
-                  Object {
-                    "order": 5,
-                    "paddingRight": "0px",
-                    "transform": "translateX(-800%)",
-                    "width": "100%",
-                  }
-                }
-              >
-                <div>
-                  2
-                </div>
-              </li>
-              <li
-                className="item"
-                key="6/.2"
-                style={
-                  Object {
-                    "order": 6,
-                    "paddingRight": "0px",
-                    "transform": "translateX(-800%)",
-                    "width": "100%",
-                  }
-                }
-              >
-                <div>
-                  3
-                </div>
-              </li>
-              <li
-                className="item"
-                key="7/.3"
-                style={
-                  Object {
-                    "order": 7,
-                    "paddingRight": "0px",
-                    "transform": "translateX(-800%)",
-                    "width": "100%",
-                  }
-                }
-              >
-                <div>
-                  4
-                </div>
-              </li>
-              <li
-                className="item"
-                key="4/.0"
-                style={
-                  Object {
-                    "order": 8,
-                    "paddingRight": "0px",
-                    "transform": "translateX(-400%)",
-                    "width": "100%",
-                  }
-                }
-              >
-                <div>
-                  1
-                </div>
-              </li>
-              <li
-                className="item"
-                key="6/.1"
-                style={
-                  Object {
-                    "order": 10,
-                    "paddingRight": "0px",
-                    "transform": "translateX(-400%)",
-                    "width": "100%",
-                  }
-                }
-              >
-                <div>
-                  2
-                </div>
-              </li>
-              <li
-                className="item"
-                key="8/.2"
-                style={
-                  Object {
-                    "order": 12,
-                    "paddingRight": "0px",
-                    "transform": "translateX(-400%)",
-                    "width": "100%",
-                  }
-                }
-              >
-                <div>
-                  3
-                </div>
-              </li>
-              <li
-                className="item"
-                key="10/.3"
-                style={
-                  Object {
-                    "order": 14,
-                    "paddingRight": "0px",
-                    "transform": "translateX(-400%)",
-                    "width": "100%",
-                  }
-                }
-              >
-                <div>
-                  4
-                </div>
-              </li>
             </ul>
           </div>
         </BaseCarousel>
@@ -723,7 +339,7 @@ exports[`\`spacing\` no spacing 1`] = `
 </Carousel>
 `;
 
-exports[`\`spacing\` spacing in ems 1`] = `
+exports[`Carousel \`spacing\` spacing in ems 1`] = `
 <Carousel
   onSelectedIndexChange={[Function]}
   selectedIndex={0}
@@ -827,134 +443,6 @@ exports[`\`spacing\` spacing in ems 1`] = `
                   4
                 </div>
               </li>
-              <li
-                className="item"
-                key="4/.0"
-                style={
-                  Object {
-                    "order": 4,
-                    "paddingRight": "2em",
-                    "transform": "translateX(-800%)",
-                    "width": "100%",
-                  }
-                }
-              >
-                <div>
-                  1
-                </div>
-              </li>
-              <li
-                className="item"
-                key="5/.1"
-                style={
-                  Object {
-                    "order": 5,
-                    "paddingRight": "2em",
-                    "transform": "translateX(-800%)",
-                    "width": "100%",
-                  }
-                }
-              >
-                <div>
-                  2
-                </div>
-              </li>
-              <li
-                className="item"
-                key="6/.2"
-                style={
-                  Object {
-                    "order": 6,
-                    "paddingRight": "2em",
-                    "transform": "translateX(-800%)",
-                    "width": "100%",
-                  }
-                }
-              >
-                <div>
-                  3
-                </div>
-              </li>
-              <li
-                className="item"
-                key="7/.3"
-                style={
-                  Object {
-                    "order": 7,
-                    "paddingRight": "2em",
-                    "transform": "translateX(-800%)",
-                    "width": "100%",
-                  }
-                }
-              >
-                <div>
-                  4
-                </div>
-              </li>
-              <li
-                className="item"
-                key="4/.0"
-                style={
-                  Object {
-                    "order": 8,
-                    "paddingRight": "2em",
-                    "transform": "translateX(-400%)",
-                    "width": "100%",
-                  }
-                }
-              >
-                <div>
-                  1
-                </div>
-              </li>
-              <li
-                className="item"
-                key="6/.1"
-                style={
-                  Object {
-                    "order": 10,
-                    "paddingRight": "2em",
-                    "transform": "translateX(-400%)",
-                    "width": "100%",
-                  }
-                }
-              >
-                <div>
-                  2
-                </div>
-              </li>
-              <li
-                className="item"
-                key="8/.2"
-                style={
-                  Object {
-                    "order": 12,
-                    "paddingRight": "2em",
-                    "transform": "translateX(-400%)",
-                    "width": "100%",
-                  }
-                }
-              >
-                <div>
-                  3
-                </div>
-              </li>
-              <li
-                className="item"
-                key="10/.3"
-                style={
-                  Object {
-                    "order": 14,
-                    "paddingRight": "2em",
-                    "transform": "translateX(-400%)",
-                    "width": "100%",
-                  }
-                }
-              >
-                <div>
-                  4
-                </div>
-              </li>
             </ul>
           </div>
         </BaseCarousel>
@@ -964,7 +452,7 @@ exports[`\`spacing\` spacing in ems 1`] = `
 </Carousel>
 `;
 
-exports[`\`spacing\` spacing in pixels 1`] = `
+exports[`Carousel \`spacing\` spacing in pixels 1`] = `
 <Carousel
   onSelectedIndexChange={[Function]}
   selectedIndex={0}
@@ -1068,134 +556,6 @@ exports[`\`spacing\` spacing in pixels 1`] = `
                   4
                 </div>
               </li>
-              <li
-                className="item"
-                key="4/.0"
-                style={
-                  Object {
-                    "order": 4,
-                    "paddingRight": "10px",
-                    "transform": "translateX(-800%)",
-                    "width": "100%",
-                  }
-                }
-              >
-                <div>
-                  1
-                </div>
-              </li>
-              <li
-                className="item"
-                key="5/.1"
-                style={
-                  Object {
-                    "order": 5,
-                    "paddingRight": "10px",
-                    "transform": "translateX(-800%)",
-                    "width": "100%",
-                  }
-                }
-              >
-                <div>
-                  2
-                </div>
-              </li>
-              <li
-                className="item"
-                key="6/.2"
-                style={
-                  Object {
-                    "order": 6,
-                    "paddingRight": "10px",
-                    "transform": "translateX(-800%)",
-                    "width": "100%",
-                  }
-                }
-              >
-                <div>
-                  3
-                </div>
-              </li>
-              <li
-                className="item"
-                key="7/.3"
-                style={
-                  Object {
-                    "order": 7,
-                    "paddingRight": "10px",
-                    "transform": "translateX(-800%)",
-                    "width": "100%",
-                  }
-                }
-              >
-                <div>
-                  4
-                </div>
-              </li>
-              <li
-                className="item"
-                key="4/.0"
-                style={
-                  Object {
-                    "order": 8,
-                    "paddingRight": "10px",
-                    "transform": "translateX(-400%)",
-                    "width": "100%",
-                  }
-                }
-              >
-                <div>
-                  1
-                </div>
-              </li>
-              <li
-                className="item"
-                key="6/.1"
-                style={
-                  Object {
-                    "order": 10,
-                    "paddingRight": "10px",
-                    "transform": "translateX(-400%)",
-                    "width": "100%",
-                  }
-                }
-              >
-                <div>
-                  2
-                </div>
-              </li>
-              <li
-                className="item"
-                key="8/.2"
-                style={
-                  Object {
-                    "order": 12,
-                    "paddingRight": "10px",
-                    "transform": "translateX(-400%)",
-                    "width": "100%",
-                  }
-                }
-              >
-                <div>
-                  3
-                </div>
-              </li>
-              <li
-                className="item"
-                key="10/.3"
-                style={
-                  Object {
-                    "order": 14,
-                    "paddingRight": "10px",
-                    "transform": "translateX(-400%)",
-                    "width": "100%",
-                  }
-                }
-              >
-                <div>
-                  4
-                </div>
-              </li>
             </ul>
           </div>
         </BaseCarousel>
@@ -1205,7 +565,7 @@ exports[`\`spacing\` spacing in pixels 1`] = `
 </Carousel>
 `;
 
-exports[`\`visibleCount\` one and a half visible items 1`] = `
+exports[`Carousel \`visibleCount\` one and a half visible items 1`] = `
 <Carousel
   onSelectedIndexChange={[Function]}
   selectedIndex={0}
@@ -1309,134 +669,6 @@ exports[`\`visibleCount\` one and a half visible items 1`] = `
                   4
                 </div>
               </li>
-              <li
-                className="item"
-                key="4/.0"
-                style={
-                  Object {
-                    "order": 4,
-                    "paddingRight": "0px",
-                    "transform": "translateX(-800%)",
-                    "width": "66.66666666666666%",
-                  }
-                }
-              >
-                <div>
-                  1
-                </div>
-              </li>
-              <li
-                className="item"
-                key="5/.1"
-                style={
-                  Object {
-                    "order": 5,
-                    "paddingRight": "0px",
-                    "transform": "translateX(-800%)",
-                    "width": "66.66666666666666%",
-                  }
-                }
-              >
-                <div>
-                  2
-                </div>
-              </li>
-              <li
-                className="item"
-                key="6/.2"
-                style={
-                  Object {
-                    "order": 6,
-                    "paddingRight": "0px",
-                    "transform": "translateX(-800%)",
-                    "width": "66.66666666666666%",
-                  }
-                }
-              >
-                <div>
-                  3
-                </div>
-              </li>
-              <li
-                className="item"
-                key="7/.3"
-                style={
-                  Object {
-                    "order": 7,
-                    "paddingRight": "0px",
-                    "transform": "translateX(-800%)",
-                    "width": "66.66666666666666%",
-                  }
-                }
-              >
-                <div>
-                  4
-                </div>
-              </li>
-              <li
-                className="item"
-                key="4/.0"
-                style={
-                  Object {
-                    "order": 8,
-                    "paddingRight": "0px",
-                    "transform": "translateX(-400%)",
-                    "width": "66.66666666666666%",
-                  }
-                }
-              >
-                <div>
-                  1
-                </div>
-              </li>
-              <li
-                className="item"
-                key="6/.1"
-                style={
-                  Object {
-                    "order": 10,
-                    "paddingRight": "0px",
-                    "transform": "translateX(-400%)",
-                    "width": "66.66666666666666%",
-                  }
-                }
-              >
-                <div>
-                  2
-                </div>
-              </li>
-              <li
-                className="item"
-                key="8/.2"
-                style={
-                  Object {
-                    "order": 12,
-                    "paddingRight": "0px",
-                    "transform": "translateX(-400%)",
-                    "width": "66.66666666666666%",
-                  }
-                }
-              >
-                <div>
-                  3
-                </div>
-              </li>
-              <li
-                className="item"
-                key="10/.3"
-                style={
-                  Object {
-                    "order": 14,
-                    "paddingRight": "0px",
-                    "transform": "translateX(-400%)",
-                    "width": "66.66666666666666%",
-                  }
-                }
-              >
-                <div>
-                  4
-                </div>
-              </li>
             </ul>
           </div>
         </BaseCarousel>
@@ -1446,7 +678,7 @@ exports[`\`visibleCount\` one and a half visible items 1`] = `
 </Carousel>
 `;
 
-exports[`\`visibleCount\` one visible item 1`] = `
+exports[`Carousel \`visibleCount\` one visible item 1`] = `
 <Carousel
   onSelectedIndexChange={[Function]}
   selectedIndex={0}
@@ -1550,134 +782,6 @@ exports[`\`visibleCount\` one visible item 1`] = `
                   4
                 </div>
               </li>
-              <li
-                className="item"
-                key="4/.0"
-                style={
-                  Object {
-                    "order": 4,
-                    "paddingRight": "0px",
-                    "transform": "translateX(-800%)",
-                    "width": "100%",
-                  }
-                }
-              >
-                <div>
-                  1
-                </div>
-              </li>
-              <li
-                className="item"
-                key="5/.1"
-                style={
-                  Object {
-                    "order": 5,
-                    "paddingRight": "0px",
-                    "transform": "translateX(-800%)",
-                    "width": "100%",
-                  }
-                }
-              >
-                <div>
-                  2
-                </div>
-              </li>
-              <li
-                className="item"
-                key="6/.2"
-                style={
-                  Object {
-                    "order": 6,
-                    "paddingRight": "0px",
-                    "transform": "translateX(-800%)",
-                    "width": "100%",
-                  }
-                }
-              >
-                <div>
-                  3
-                </div>
-              </li>
-              <li
-                className="item"
-                key="7/.3"
-                style={
-                  Object {
-                    "order": 7,
-                    "paddingRight": "0px",
-                    "transform": "translateX(-800%)",
-                    "width": "100%",
-                  }
-                }
-              >
-                <div>
-                  4
-                </div>
-              </li>
-              <li
-                className="item"
-                key="4/.0"
-                style={
-                  Object {
-                    "order": 8,
-                    "paddingRight": "0px",
-                    "transform": "translateX(-400%)",
-                    "width": "100%",
-                  }
-                }
-              >
-                <div>
-                  1
-                </div>
-              </li>
-              <li
-                className="item"
-                key="6/.1"
-                style={
-                  Object {
-                    "order": 10,
-                    "paddingRight": "0px",
-                    "transform": "translateX(-400%)",
-                    "width": "100%",
-                  }
-                }
-              >
-                <div>
-                  2
-                </div>
-              </li>
-              <li
-                className="item"
-                key="8/.2"
-                style={
-                  Object {
-                    "order": 12,
-                    "paddingRight": "0px",
-                    "transform": "translateX(-400%)",
-                    "width": "100%",
-                  }
-                }
-              >
-                <div>
-                  3
-                </div>
-              </li>
-              <li
-                className="item"
-                key="10/.3"
-                style={
-                  Object {
-                    "order": 14,
-                    "paddingRight": "0px",
-                    "transform": "translateX(-400%)",
-                    "width": "100%",
-                  }
-                }
-              >
-                <div>
-                  4
-                </div>
-              </li>
             </ul>
           </div>
         </BaseCarousel>
@@ -1687,7 +791,7 @@ exports[`\`visibleCount\` one visible item 1`] = `
 </Carousel>
 `;
 
-exports[`\`visibleCount\` three visible items 1`] = `
+exports[`Carousel \`visibleCount\` three visible items 1`] = `
 <Carousel
   onSelectedIndexChange={[Function]}
   selectedIndex={0}
@@ -1791,134 +895,6 @@ exports[`\`visibleCount\` three visible items 1`] = `
                   4
                 </div>
               </li>
-              <li
-                className="item"
-                key="4/.0"
-                style={
-                  Object {
-                    "order": 4,
-                    "paddingRight": "0px",
-                    "transform": "translateX(-800%)",
-                    "width": "33.33333333333333%",
-                  }
-                }
-              >
-                <div>
-                  1
-                </div>
-              </li>
-              <li
-                className="item"
-                key="5/.1"
-                style={
-                  Object {
-                    "order": 5,
-                    "paddingRight": "0px",
-                    "transform": "translateX(-800%)",
-                    "width": "33.33333333333333%",
-                  }
-                }
-              >
-                <div>
-                  2
-                </div>
-              </li>
-              <li
-                className="item"
-                key="6/.2"
-                style={
-                  Object {
-                    "order": 6,
-                    "paddingRight": "0px",
-                    "transform": "translateX(-800%)",
-                    "width": "33.33333333333333%",
-                  }
-                }
-              >
-                <div>
-                  3
-                </div>
-              </li>
-              <li
-                className="item"
-                key="7/.3"
-                style={
-                  Object {
-                    "order": 7,
-                    "paddingRight": "0px",
-                    "transform": "translateX(-800%)",
-                    "width": "33.33333333333333%",
-                  }
-                }
-              >
-                <div>
-                  4
-                </div>
-              </li>
-              <li
-                className="item"
-                key="4/.0"
-                style={
-                  Object {
-                    "order": 8,
-                    "paddingRight": "0px",
-                    "transform": "translateX(-400%)",
-                    "width": "33.33333333333333%",
-                  }
-                }
-              >
-                <div>
-                  1
-                </div>
-              </li>
-              <li
-                className="item"
-                key="6/.1"
-                style={
-                  Object {
-                    "order": 10,
-                    "paddingRight": "0px",
-                    "transform": "translateX(-400%)",
-                    "width": "33.33333333333333%",
-                  }
-                }
-              >
-                <div>
-                  2
-                </div>
-              </li>
-              <li
-                className="item"
-                key="8/.2"
-                style={
-                  Object {
-                    "order": 12,
-                    "paddingRight": "0px",
-                    "transform": "translateX(-400%)",
-                    "width": "33.33333333333333%",
-                  }
-                }
-              >
-                <div>
-                  3
-                </div>
-              </li>
-              <li
-                className="item"
-                key="10/.3"
-                style={
-                  Object {
-                    "order": 14,
-                    "paddingRight": "0px",
-                    "transform": "translateX(-400%)",
-                    "width": "33.33333333333333%",
-                  }
-                }
-              >
-                <div>
-                  4
-                </div>
-              </li>
             </ul>
           </div>
         </BaseCarousel>
@@ -1928,7 +904,7 @@ exports[`\`visibleCount\` three visible items 1`] = `
 </Carousel>
 `;
 
-exports[`renders a carousel 1`] = `
+exports[`Carousel renders a carousel 1`] = `
 <Carousel
   onSelectedIndexChange={[Function]}
   selectedIndex={0}
@@ -1979,34 +955,6 @@ exports[`renders a carousel 1`] = `
                   Object {
                     "order": 0,
                     "paddingRight": "0px",
-                    "width": "100%",
-                  }
-                }
-              >
-                gooose
-              </li>
-              <li
-                className="item"
-                key="6/.0"
-                style={
-                  Object {
-                    "order": 6,
-                    "paddingRight": "0px",
-                    "transform": "translateX(-1200%)",
-                    "width": "100%",
-                  }
-                }
-              >
-                gooose
-              </li>
-              <li
-                className="item"
-                key="6/.0"
-                style={
-                  Object {
-                    "order": 12,
-                    "paddingRight": "0px",
-                    "transform": "translateX(-600%)",
                     "width": "100%",
                   }
                 }

--- a/packages/thumbprint-react/components/Carousel/base-carousel.jsx
+++ b/packages/thumbprint-react/components/Carousel/base-carousel.jsx
@@ -11,6 +11,8 @@ export default function BaseCarousel({
     visibleCount,
     spacing,
 }) {
+    // When animating, `prevSelectedIndex` is the value of `selectedIndex` before the
+    // animation began. Once the animation is complete, it becomes the same as `selectedIndex`.
     const [prevSelectedIndex, setPrevSelectedIndex] = useState(selectedIndex);
     const [isAnimating, setIsAnimating] = useState(false);
     const [isSuspensed, setIsSuspensed] = useState(false);

--- a/packages/thumbprint-react/components/Carousel/base-carousel.jsx
+++ b/packages/thumbprint-react/components/Carousel/base-carousel.jsx
@@ -1,17 +1,8 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import rotate from 'rotate-array';
 import range from 'lodash/range';
 import styles from './base-carousel.module.scss';
-
-// Utility function from https://reactjs.org/docs/hooks-faq.html#how-to-get-the-previous-props-or-state
-function usePrevious(value) {
-    const ref = useRef();
-    useEffect(() => {
-        ref.current = value;
-    });
-    return ref.current;
-}
 
 export default function BaseCarousel({
     children,
@@ -20,32 +11,9 @@ export default function BaseCarousel({
     visibleCount,
     spacing,
 }) {
-    // When animating, `prevSelectedIndex` is the value of `selectedIndex` before the
-    // animation began. Once the animation is complete, it becomes the same as `selectedIndex`.
     const [prevSelectedIndex, setPrevSelectedIndex] = useState(selectedIndex);
     const [isAnimating, setIsAnimating] = useState(false);
     const [isSuspensed, setIsSuspensed] = useState(false);
-
-    const prevSelectedIndexProp = usePrevious(selectedIndex);
-
-    function setAnimating() {
-        setIsAnimating(true);
-        setIsSuspensed(false);
-
-        setTimeout(() => {
-            setIsAnimating(false);
-            setIsSuspensed(true);
-            setPrevSelectedIndex(selectedIndex);
-
-            // We suspend the CSS animation property for a very brief window before
-            // re-enabling. This gap allows the component to re-render the new list
-            // without the items "sliding" back into place. Once the new items are set up,
-            // we re-enable the animation property ready for the next transition.
-            setTimeout(() => {
-                setIsSuspensed(false);
-            }, 50);
-        }, animationDuration);
-    }
 
     function reorder(items) {
         // The `prevSelectedIndex` doesn't update until the animation is done, so we want to
@@ -53,11 +21,29 @@ export default function BaseCarousel({
         return rotate(items, -1 * Math.floor(prevSelectedIndex));
     }
 
-    useEffect(() => {
-        if (selectedIndex !== prevSelectedIndexProp) {
-            setAnimating();
-        }
-    });
+    useEffect(
+        () => {
+            if (selectedIndex !== prevSelectedIndex) {
+                setIsAnimating(true);
+                setIsSuspensed(false);
+
+                setTimeout(() => {
+                    setIsAnimating(false);
+                    setIsSuspensed(true);
+                    setPrevSelectedIndex(selectedIndex);
+
+                    // We suspend the CSS animation property for a very brief window before
+                    // re-enabling. This gap allows the component to re-render the new list
+                    // without the items "sliding" back into place. Once the new items are set up,
+                    // we re-enable the animation property ready for the next transition.
+                    setTimeout(() => {
+                        setIsSuspensed(false);
+                    }, 50);
+                }, animationDuration);
+            }
+        },
+        [animationDuration, prevSelectedIndex, selectedIndex],
+    );
 
     const itemWidth = 1 / visibleCount;
 
@@ -74,8 +60,10 @@ export default function BaseCarousel({
     // transition is occuring.
     const translateX = itemWidth * (adjustedIndex + fractionalIndexOffset) * -100;
 
+    const numChildren = React.Children.count(children);
+
     // An array of the flex order of the items.
-    const orderedChildren = reorder(range(children.length));
+    const childOrders = reorder(range(numChildren));
 
     // Sometimes we need to duplicate the children so that the carousel can display properly.
     // This is especially needed when animating. Imagine that a 4-item card with 3 visible
@@ -101,7 +89,7 @@ export default function BaseCarousel({
                         style={{
                             width: `${itemWidth * 100}%`,
                             paddingRight: spacing,
-                            order: orderedChildren[i],
+                            order: childOrders[i],
                         }}
                     >
                         {child}
@@ -110,15 +98,15 @@ export default function BaseCarousel({
 
                 {/* Temporary elements that appear to the left. */}
                 {shouldRenderDuplicateChildren &&
-                    React.Children.map(children, (child, i) => (
+                    React.Children.map(children, (child, index) => (
                         <li
-                            key={orderedChildren.length + i}
+                            key={numChildren + index}
                             className={styles.item}
                             style={{
                                 width: `${itemWidth * 100}%`,
                                 paddingRight: spacing,
-                                order: orderedChildren[i] + orderedChildren.length,
-                                transform: `translateX(${children.length * -200}%)`,
+                                order: childOrders[index] + numChildren,
+                                transform: `translateX(${numChildren * -200}%)`,
                             }}
                         >
                             {child}
@@ -127,15 +115,15 @@ export default function BaseCarousel({
 
                 {/* Temporary elements that appear to the right. */}
                 {shouldRenderDuplicateChildren &&
-                    React.Children.map(children, (child, i) => (
+                    React.Children.map(children, (child, index) => (
                         <li
-                            key={orderedChildren.length + i * 2}
+                            key={numChildren + index * 2}
                             className={styles.item}
                             style={{
                                 width: `${itemWidth * 100}%`,
                                 paddingRight: spacing,
-                                order: (orderedChildren[i] + orderedChildren.length) * 2,
-                                transform: `translateX(${children.length * -100}%)`,
+                                order: (childOrders[index] + numChildren) * 2,
+                                transform: `translateX(${numChildren * -100}%)`,
                             }}
                         >
                             {child}

--- a/packages/thumbprint-react/components/Carousel/test.jsx
+++ b/packages/thumbprint-react/components/Carousel/test.jsx
@@ -3,113 +3,125 @@ import { mount } from 'enzyme';
 import { noop } from 'lodash';
 import Carousel from './index';
 
-test('renders a carousel', () => {
-    const wrapper = mount(
-        <Carousel selectedIndex={0} onSelectedIndexChange={noop}>
-            gooose
-        </Carousel>,
-    );
-    expect(wrapper).toMatchSnapshot();
-});
-
-describe('`selectedIndex`', () => {
-    test('supports decimal `selectedIndex` values', () => {
+describe('Carousel', () => {
+    test('renders a carousel', () => {
         const wrapper = mount(
-            <Carousel selectedIndex={2.3} onSelectedIndexChange={noop}>
-                <div>1</div>
-                <div>2</div>
-                <div>3</div>
-                <div>4</div>
+            <Carousel selectedIndex={0} onSelectedIndexChange={noop}>
+                gooose
             </Carousel>,
         );
         expect(wrapper).toMatchSnapshot();
     });
 
-    test('supports negative `selectedIndex`', () => {
+    test('does not render duplicate children when not animating', () => {
         const wrapper = mount(
-            <Carousel selectedIndex={-0.8} onSelectedIndexChange={noop}>
-                <div>1</div>
-                <div>2</div>
-                <div>3</div>
-                <div>4</div>
+            <Carousel selectedIndex={0} onSelectedIndexChange={noop}>
+                <div data-test="item">Goose</div>
             </Carousel>,
         );
-        expect(wrapper).toMatchSnapshot();
-    });
-});
 
-describe('`visibleCount`', () => {
-    test('one visible item', () => {
-        const wrapper = mount(
-            <Carousel selectedIndex={0} visibleCount={1} onSelectedIndexChange={noop}>
-                <div>1</div>
-                <div>2</div>
-                <div>3</div>
-                <div>4</div>
-            </Carousel>,
-        );
-        expect(wrapper).toMatchSnapshot();
+        expect(wrapper.find('[data-test="item"]')).toHaveLength(1);
     });
 
-    test('one and a half visible items', () => {
-        const wrapper = mount(
-            <Carousel selectedIndex={0} visibleCount={1.5} onSelectedIndexChange={noop}>
-                <div>1</div>
-                <div>2</div>
-                <div>3</div>
-                <div>4</div>
-            </Carousel>,
-        );
-        expect(wrapper).toMatchSnapshot();
+    describe('`selectedIndex`', () => {
+        test('supports decimal `selectedIndex` values', () => {
+            const wrapper = mount(
+                <Carousel selectedIndex={2.3} onSelectedIndexChange={noop}>
+                    <div>1</div>
+                    <div>2</div>
+                    <div>3</div>
+                    <div>4</div>
+                </Carousel>,
+            );
+            expect(wrapper).toMatchSnapshot();
+        });
+
+        test('supports negative `selectedIndex`', () => {
+            const wrapper = mount(
+                <Carousel selectedIndex={-0.8} onSelectedIndexChange={noop}>
+                    <div>1</div>
+                    <div>2</div>
+                    <div>3</div>
+                    <div>4</div>
+                </Carousel>,
+            );
+            expect(wrapper).toMatchSnapshot();
+        });
     });
 
-    test('three visible items', () => {
-        const wrapper = mount(
-            <Carousel selectedIndex={0} visibleCount={3} onSelectedIndexChange={noop}>
-                <div>1</div>
-                <div>2</div>
-                <div>3</div>
-                <div>4</div>
-            </Carousel>,
-        );
-        expect(wrapper).toMatchSnapshot();
-    });
-});
+    describe('`visibleCount`', () => {
+        test('one visible item', () => {
+            const wrapper = mount(
+                <Carousel selectedIndex={0} visibleCount={1} onSelectedIndexChange={noop}>
+                    <div>1</div>
+                    <div>2</div>
+                    <div>3</div>
+                    <div>4</div>
+                </Carousel>,
+            );
+            expect(wrapper).toMatchSnapshot();
+        });
 
-describe('`spacing`', () => {
-    test('no spacing', () => {
-        const wrapper = mount(
-            <Carousel selectedIndex={0} spacing="0px" onSelectedIndexChange={noop}>
-                <div>1</div>
-                <div>2</div>
-                <div>3</div>
-                <div>4</div>
-            </Carousel>,
-        );
-        expect(wrapper).toMatchSnapshot();
+        test('one and a half visible items', () => {
+            const wrapper = mount(
+                <Carousel selectedIndex={0} visibleCount={1.5} onSelectedIndexChange={noop}>
+                    <div>1</div>
+                    <div>2</div>
+                    <div>3</div>
+                    <div>4</div>
+                </Carousel>,
+            );
+            expect(wrapper).toMatchSnapshot();
+        });
+
+        test('three visible items', () => {
+            const wrapper = mount(
+                <Carousel selectedIndex={0} visibleCount={3} onSelectedIndexChange={noop}>
+                    <div>1</div>
+                    <div>2</div>
+                    <div>3</div>
+                    <div>4</div>
+                </Carousel>,
+            );
+            expect(wrapper).toMatchSnapshot();
+        });
     });
 
-    test('spacing in pixels', () => {
-        const wrapper = mount(
-            <Carousel selectedIndex={0} spacing="10px" onSelectedIndexChange={noop}>
-                <div>1</div>
-                <div>2</div>
-                <div>3</div>
-                <div>4</div>
-            </Carousel>,
-        );
-        expect(wrapper).toMatchSnapshot();
-    });
+    describe('`spacing`', () => {
+        test('no spacing', () => {
+            const wrapper = mount(
+                <Carousel selectedIndex={0} spacing="0px" onSelectedIndexChange={noop}>
+                    <div>1</div>
+                    <div>2</div>
+                    <div>3</div>
+                    <div>4</div>
+                </Carousel>,
+            );
+            expect(wrapper).toMatchSnapshot();
+        });
 
-    test('spacing in ems', () => {
-        const wrapper = mount(
-            <Carousel selectedIndex={0} spacing="2em" onSelectedIndexChange={noop}>
-                <div>1</div>
-                <div>2</div>
-                <div>3</div>
-                <div>4</div>
-            </Carousel>,
-        );
-        expect(wrapper).toMatchSnapshot();
+        test('spacing in pixels', () => {
+            const wrapper = mount(
+                <Carousel selectedIndex={0} spacing="10px" onSelectedIndexChange={noop}>
+                    <div>1</div>
+                    <div>2</div>
+                    <div>3</div>
+                    <div>4</div>
+                </Carousel>,
+            );
+            expect(wrapper).toMatchSnapshot();
+        });
+
+        test('spacing in ems', () => {
+            const wrapper = mount(
+                <Carousel selectedIndex={0} spacing="2em" onSelectedIndexChange={noop}>
+                    <div>1</div>
+                    <div>2</div>
+                    <div>3</div>
+                    <div>4</div>
+                </Carousel>,
+            );
+            expect(wrapper).toMatchSnapshot();
+        });
     });
 });

--- a/www/src/pages/components/carousel/react/index.mdx
+++ b/www/src/pages/components/carousel/react/index.mdx
@@ -33,28 +33,28 @@ function CarouselDemo() {
                         alt="Personal Training"
                         url="https://d1vg1gqh4nkuns.cloudfront.net/i/328491711124668465/small/standard/hero"
                     />
-                    <ServiceCardTitle>Personal Training</ServiceCardTitle>
+                    <ServiceCardTitle>1. Personal Training</ServiceCardTitle>
                 </ServiceCard>
                 <ServiceCard url="https://www.thumbtack.com/k/massage/near-me/">
                     <ServiceCardImage
                         alt="Dog Training"
                         url="https://d1vg1gqh4nkuns.cloudfront.net/i/323761411685384319/small/standard/hero"
                     />
-                    <ServiceCardTitle>Dog Training</ServiceCardTitle>
+                    <ServiceCardTitle>2. Dog Training</ServiceCardTitle>
                 </ServiceCard>
                 <ServiceCard url="https://www.thumbtack.com/k/massage/near-me/">
                     <ServiceCardImage
                         alt="Local Moving (under 50 miles)"
                         url="https://picsum.photos/666/417/?image=300"
                     />
-                    <ServiceCardTitle>Local Moving (under 50 miles)</ServiceCardTitle>
+                    <ServiceCardTitle>3. Local Moving</ServiceCardTitle>
                 </ServiceCard>
                 <ServiceCard url="https://www.thumbtack.com/k/massage/near-me/">
                     <ServiceCardImage
                         alt="Massage Therapy"
                         url="https://d1vg1gqh4nkuns.cloudfront.net/i/323761720722374783/small/standard/hero"
                     />
-                    <ServiceCardTitle>Massage Therapy</ServiceCardTitle>
+                    <ServiceCardTitle>4. Massage Therapy</ServiceCardTitle>
                 </ServiceCard>
             </Carousel>
 


### PR DESCRIPTION
The carousel was rendering duplicate children even when not animating due to the `useEffect` hook running at the wrong times.

- Fix this bug by following Rules of Hooks
- Remove confusing duplicated logic around tracking previous selected index
- Add a unit test for this case
- Update all snapshots