### PR TITLE
Remove noscript from image when forceEarlyRender is set

### DIFF
--- a/packages/thumbprint-react/CHANGELOG.md
+++ b/packages/thumbprint-react/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+-   [Patch] Prevent noscript image when `forceEarlyRender` prop is used.
+
 ## 9.1.0 - 2019-08-22
 
 ### Added

--- a/packages/thumbprint-react/components/Image/index.jsx
+++ b/packages/thumbprint-react/components/Image/index.jsx
@@ -237,9 +237,11 @@ const Image = forwardRef((props, outerRef) => {
                     })}
                 />
             </picture>
-            <noscript>
-                <img src={src} alt={alt} />
-            </noscript>
+            {!forceEarlyRender && (
+                <noscript>
+                    <img src={src} alt={alt} />
+                </noscript>
+            )}
         </>
     );
 });


### PR DESCRIPTION
When forceEarlylRender is set, we don't need a <noscript> image tag since we will always render an image tag.