### PR TITLE
Upgrade `node-sass-tilde-importer`.

### DIFF
--- a/packages/gatsby-transformer-thumbprint-atomic/package.json
+++ b/packages/gatsby-transformer-thumbprint-atomic/package.json
@@ -6,7 +6,7 @@
         "gonzales-pe": "^4.2.3",
         "lodash": "^4.17.10",
         "node-sass": "^4.11.0",
-        "node-sass-tilde-importer": "1.0.0",
+        "node-sass-tilde-importer": "2.0.0-alpha.1",
         "prettier": "1.18.2"
     }
 }

--- a/packages/thumbprint-atomic/CHANGELOG.md
+++ b/packages/thumbprint-atomic/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+-   [Patch] Upgrade `node-sass-tilde-importer`, a `devDependency`. This does not affect the outputted code.
+
 ## 3.2.15 - 2019-08-21
 
 ### Changed

--- a/packages/thumbprint-atomic/package.json
+++ b/packages/thumbprint-atomic/package.json
@@ -26,7 +26,7 @@
         "css-mqpacker": "^7.0.0",
         "cssnano": "^4.1.0",
         "node-sass": "^4.9.2",
-        "node-sass-tilde-importer": "1.0.0",
+        "node-sass-tilde-importer": "2.0.0-alpha.1",
         "postcss-cli": "^6.1.1"
     }
 }

--- a/packages/thumbprint-font-face/CHANGELOG.md
+++ b/packages/thumbprint-font-face/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+-   [Patch] Upgrade `node-sass-tilde-importer`, a `devDependency`. This does not affect the outputted code.
+
 ## 1.0.10 - 2019-08-21
 
 ### Changed

--- a/packages/thumbprint-font-face/package.json
+++ b/packages/thumbprint-font-face/package.json
@@ -31,7 +31,7 @@
         "@thumbtack/thumbprint-tokens": "^8.3.0"
     },
     "devDependencies": {
-        "node-sass-tilde-importer": "1.0.0",
+        "node-sass-tilde-importer": "2.0.0-alpha.1",
         "tmp": "^0.0.33"
     }
 }

--- a/packages/thumbprint-global-css/CHANGELOG.md
+++ b/packages/thumbprint-global-css/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+-   [Patch] Upgrade `node-sass-tilde-importer`, a `devDependency`. This does not affect the outputted code.
+
 ## 0.1.13 - 2019-08-21
 
 ### Changed

--- a/packages/thumbprint-global-css/package.json
+++ b/packages/thumbprint-global-css/package.json
@@ -24,7 +24,7 @@
         "autoprefixer": "^9.0.1",
         "cssnano": "^4.1.0",
         "node-sass": "^4.9.2",
-        "node-sass-tilde-importer": "1.0.0",
+        "node-sass-tilde-importer": "2.0.0-alpha.1",
         "postcss-cli": "^6.1.1"
     },
     "bugs": {

--- a/packages/thumbprint-scss/CHANGELOG.md
+++ b/packages/thumbprint-scss/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+-   [Patch] Upgrade `node-sass-tilde-importer`, a `devDependency`. This does not affect the outputted code.
+
 ## 2.0.5 - 2019-08-21
 
 ### Changed

--- a/packages/thumbprint-scss/package.json
+++ b/packages/thumbprint-scss/package.json
@@ -36,7 +36,7 @@
         "fs-extra": "^7.0.1",
         "glob": "^7.1.3",
         "node-sass": "^4.9.2",
-        "node-sass-tilde-importer": "1.0.0",
+        "node-sass-tilde-importer": "2.0.0-alpha.1",
         "p-map": "^2.0.0",
         "postcss-cli": "^6.1.1"
     }

--- a/www/package.json
+++ b/www/package.json
@@ -32,7 +32,7 @@
         "invariant": "^2.2.4",
         "lodash": "^4.17.4",
         "mousetrap": "^1.6.2",
-        "node-sass-tilde-importer": "1.0.0",
+        "node-sass-tilde-importer": "2.0.0-alpha.1",
         "postcss-import": "^12.0.0",
         "prism-react-renderer": "0.1.7",
         "prop-types": "^15.7.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11849,10 +11849,10 @@ node-releases@^1.1.25:
   dependencies:
     semver "^5.3.0"
 
-node-sass-tilde-importer@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/node-sass-tilde-importer/-/node-sass-tilde-importer-1.0.0.tgz#653d048a270464a1865ef9a99cc80ee2d80f9c97"
-  integrity sha1-ZT0EiicEZKGGXvmpnMgO4tgPnJc=
+node-sass-tilde-importer@2.0.0-alpha.1:
+  version "2.0.0-alpha.1"
+  resolved "https://registry.yarnpkg.com/node-sass-tilde-importer/-/node-sass-tilde-importer-2.0.0-alpha.1.tgz#137de41296eeeba87ba6dd19ddb62799868d94aa"
+  integrity sha512-XRnPx+wxbFyl546rxaQ/NAEZ8v1mfrvqvKpipdxrlxdrNYOiqg1rQT2Cp6J3293ZeqE+fqL1p4sHlOckTKFneg==
   dependencies:
     find-parent-dir "^0.3.0"
 


### PR DESCRIPTION
We had to use an old version because the newest one didn't support SCSS files.

This has since been fixed as `2.0.0-alpha.1`:
https://github.com/matthewdavidson/node-sass-tilde-importer/pull/11#issuecomment-463264184