### PR TITLE
Upgrade `fs-extra`.

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
         "eslint-plugin-react-hooks": "^1.6.1",
         "execa": "^2.0.4",
         "folder-hash": "^3.0.0",
-        "fs-extra": "^7.0.0",
+        "fs-extra": "^8.1.0",
         "husky": "^1.1.2",
         "identity-obj-proxy": "^3.0.0",
         "jest": "^24.0.0",

--- a/packages/thumbprint-scss/CHANGELOG.md
+++ b/packages/thumbprint-scss/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 -   [Patch] Upgrade `node-sass-tilde-importer`, a `devDependency`. This does not affect the outputted code.
+-   [Patch] Upgrade `fs-extra`, a `devDependency`. This does not affect the outputted code.
 
 ## 2.0.5 - 2019-08-21
 

--- a/packages/thumbprint-scss/package.json
+++ b/packages/thumbprint-scss/package.json
@@ -33,7 +33,7 @@
         "@thumbtack/thumbprint-tokens": "^8.3.0",
         "autoprefixer": "^9.0.1",
         "cssnano": "^4.1.0",
-        "fs-extra": "^7.0.1",
+        "fs-extra": "^8.1.0",
         "glob": "^7.1.3",
         "node-sass": "^4.9.2",
         "node-sass-tilde-importer": "2.0.0-alpha.1",

--- a/packages/thumbprint-tokens/CHANGELOG.md
+++ b/packages/thumbprint-tokens/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+-   [Patch] Upgrade `fs-extra`, a `devDependency`. This does not affect the outputted code.
+
 ## 8.3.0 - 2019-08-21
 
 ### Added

--- a/packages/thumbprint-tokens/package.json
+++ b/packages/thumbprint-tokens/package.json
@@ -19,7 +19,7 @@
     "author": "Daniel O'Connor <daniel@danoc.me>",
     "license": "Apache-2.0",
     "devDependencies": {
-        "fs-extra": "^5.0.0",
+        "fs-extra": "^8.1.0",
         "glob": "^7.1.2",
         "handlebars": "^4.1.1",
         "lodash": "^4.17.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7339,6 +7339,15 @@ fs-extra@^7.0.0, fs-extra@^7.0.1:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
+fs-extra@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-8.1.0.tgz#49d43c45a88cd9677668cb7be1b46efdb8d2e1c0"
+  integrity sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==
+  dependencies:
+    graceful-fs "^4.2.0"
+    jsonfile "^4.0.0"
+    universalify "^0.1.0"
+
 fs-minipass@^1.2.5:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.6.tgz#2c5cc30ded81282bfe8a0d7c7c1853ddeb102c07"
@@ -8236,7 +8245,7 @@ got@^7.1.0:
     url-parse-lax "^1.0.0"
     url-to-options "^1.0.1"
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6:
+graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.2.tgz#6f0952605d0140c1cfdb138ed005775b92d67b02"
   integrity sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==


### PR DESCRIPTION
Has breaking changes, but no upgrade work is needed. The package is used to generate Tokens and SCSS output files.