### PR TITLE
Replace incorrect CSS class in example

### DIFF
--- a/www/src/pages/components/link/scss/index.mdx
+++ b/www/src/pages/components/link/scss/index.mdx
@@ -33,7 +33,7 @@ Blue links are the most common link style. No CSS class is needed since the styl
 These links render as white text with an underline. They work well on dark backgrounds.
 
 ```jsx theme=dark
-<div class="tp-color--white">
+<div class="white">
     Learn more about{' '}
     <a class="tp-link--tertiary" href="https://www.facebook.com/Thumbtack/">
         Thumbtack on Facebook


### PR DESCRIPTION
`tp-color--white` no longer exists and was replaced with `white` once Atomic came out.