### PR TITLE
Generate types for index.ts so consumers can access type definitions

### DIFF
--- a/packages/thumbprint-react/tsconfig.types.json
+++ b/packages/thumbprint-react/tsconfig.types.json
@@ -20,6 +20,6 @@
         // re-enable this rule.
         "noImplicitAny": false
     },
-    "include": ["components/**/*.tsx", "../../typings/**/*"],
+    "include": ["index.ts", "components/**/*.tsx", "../../typings/**/*"],
     "exclude": ["**/*test.tsx"]
 }


### PR DESCRIPTION
Looks like you do need definitions for your index file, otherwise TS won't typecheck the components when used in website.

Once this is merged I'll publish it as 9.5.2, then I can install the new typescripted components into website