### PR TITLE
Enforce line-height to prevent misalignment

### DIFF
--- a/packages/thumbprint-react/CHANGELOG.md
+++ b/packages/thumbprint-react/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Fixed
 
+-   [Patch] Add `line-height` to `Pill` to ensure alignment, prevent external value inheritance. (#494)
+
+### Fixed
+
 -   [Patch] Enable `size` prop to properly pass through a `number` to the `Image` height. (#486)
 
 ### Changed

--- a/packages/thumbprint-react/components/Pill/index.module.scss
+++ b/packages/thumbprint-react/components/Pill/index.module.scss
@@ -9,6 +9,7 @@
     color: $tp-color__black;
     display: inline-block;
     font-size: $tp-font__body__2__size;
+    line-height: 23px; // Non-standard line-height to properly vertical align.
     font-weight: $tp-font-weight__bold;
     overflow: hidden;
 }


### PR DESCRIPTION
This uses a non-standard `line-height` value to align inside the `inline-block` element. The height of the container remains `24px`. Fixes #494 