### PR TITLE
Fix related components in Netlify CMS files

### DIFF
--- a/www/gatsby-node.js
+++ b/www/gatsby-node.js
@@ -142,7 +142,7 @@ exports.createPages = async ({ graphql, actions, reporter }) => {
             component: path.resolve(`./src/components/cms/index.jsx`),
             context: {
                 id: node.childMdx.id,
-                relatedComponentsGlob: '/components/avatar/*/',
+                relatedComponentsGlob: `/components/${node.name}/*/`,
                 isComponent: true,
             },
         });


### PR DESCRIPTION
The glob is used to populate the platform tab navigation at the top of the component pages.