### PR TITLE
Fix sidebar links to CMS powered pages

### DIFF
--- a/www/gatsby-node.js
+++ b/www/gatsby-node.js
@@ -109,6 +109,10 @@ exports.createPages = async ({ graphql, actions, reporter }) => {
                         relativePath
                         childMdx {
                             id
+                            frontmatter {
+                                title
+                                description
+                            }
                         }
                     }
                 }
@@ -144,6 +148,10 @@ exports.createPages = async ({ graphql, actions, reporter }) => {
                 id: node.childMdx.id,
                 relatedComponentsGlob: `/components/${node.name}/*/`,
                 isComponent: true,
+                frontmatter: {
+                    title: node.childMdx.frontmatter.title,
+                    description: node.childMdx.frontmatter.description,
+                },
             },
         });
     });


### PR DESCRIPTION
This fixes a bug where CMS powered "Usage" pages were not getting linked to in the sidebar. Instead, the links were going straight to the "React" or "SCSS" documentation.

This was happening because the CMS pages were not getting picked up by the GraphQL query used to display components in the sidebar. This is the query:

```graphql
allComponents: allSitePage(
    filter: {
        path: {
            glob: "/components/*/*/"
            nin: [
                "/components/overview/"
                "/components/global-css/scss/"
                "/components/mixins/scss/"
            ]
        }
        context: { frontmatter: { unlisted: { ne: true } } }
    }
) {
    group(field: context___frontmatter___title) {
        fieldValue
        edges {
            node {
                path
                context {
                    frontmatter {
                        title
                    }
                }
            }
        }
    }
}
```

The CMS pages (created by `createPage` in `gatsby-node.js`) don't automatically have a `context___frontmatter___title`. This change passes the context and fixes the issue.