### PR TITLE
Fix the package install instructions

### DIFF
--- a/www/src/components/package-table/index.jsx
+++ b/www/src/components/package-table/index.jsx
@@ -76,7 +76,7 @@ const PackageTable = ({
                     <tr className={styles.tr}>
                         <th className={styles.th}>Install:</th>
                         <td className={styles.td}>
-                            {(platform === 'javascript' || platform === 'scss') && (
+                            {platform === 'web' && (
                                 <InlineCode theme="plain" shouldCopyToClipboard>
                                     {`yarn add ${name} ${isStable ? '--exact' : ''}`}
                                 </InlineCode>

--- a/www/src/pages/tokens/javascript/index.mdx
+++ b/www/src/pages/tokens/javascript/index.mdx
@@ -40,7 +40,7 @@ export const pageQuery = graphql`
     version={props.data.thumbprintToken.version}
     packageName="@thumbtack/thumbprint-tokens"
     sourceDirectory="https://github.com/thumbtack/thumbprint-tokens"
-    platform="javascript"
+    platform="web"
     importStatement="import * as tokens from '@thumbtack/thumbprint-tokens';"
 />
 

--- a/www/src/pages/tokens/scss/index.mdx
+++ b/www/src/pages/tokens/scss/index.mdx
@@ -42,7 +42,7 @@ export const pageQuery = graphql`
     version={props.data.thumbprintToken.version}
     packageName="@thumbtack/thumbprint-tokens"
     sourceDirectory="https://github.com/thumbtack/thumbprint-tokens"
-    platform="scss"
+    platform="web"
     importStatement={`@import "@thumbtack/thumbprint-tokens/dist/scss/_index";`}
 />
 


### PR DESCRIPTION
It had disappeared in a recent change to the tokens documentation.