### PR TITLE
Add checkbox and radio wrap classes

### DIFF
--- a/packages/thumbprint-scss/CHANGELOG.md
+++ b/packages/thumbprint-scss/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+-   [Minor] Add checkbox and radio wrap classes that will replace `tp-input-wrap`.
+
 ## 3.0.0 - 2019-11-20
 
 ### Removed

--- a/packages/thumbprint-scss/__snapshots__/test.js.snap
+++ b/packages/thumbprint-scss/__snapshots__/test.js.snap
@@ -426,6 +426,18 @@ exports[`compiles correctly 1`] = `
 .tp-button-row__right {
   margin-left: auto;
 }
+.tp-checkbox-wrap {
+  position: relative;
+}
+.tp-checkbox-wrap .tp-label {
+  padding-left: 28px;
+  font-weight: 400;
+  cursor: pointer;
+  position: relative;
+}
+.tp-checkbox-wrap + .tp-checkbox-wrap {
+  margin-top: 8px;
+}
 .tp-checkbox-input {
   position: absolute;
   opacity: 0;
@@ -1476,6 +1488,15 @@ _:-ms-fullscreen {
 }
 .tp-radio-wrap {
   position: relative;
+}
+.tp-radio-wrap .tp-label {
+  padding-left: 28px;
+  font-weight: 400;
+  cursor: pointer;
+  position: relative;
+}
+.tp-radio-wrap + .tp-radio-wrap {
+  margin-top: 8px;
 }
 .tp-radio-input {
   position: absolute;

--- a/packages/thumbprint-scss/scss/checkbox.scss
+++ b/packages/thumbprint-scss/scss/checkbox.scss
@@ -1,5 +1,20 @@
 @import '~@thumbtack/thumbprint-tokens/dist/scss/_index.scss';
 
+.tp-checkbox-wrap {
+    position: relative;
+
+    & .tp-label {
+        padding-left: 28px;
+        font-weight: 400;
+        cursor: pointer;
+        position: relative;
+    }
+
+    + .tp-checkbox-wrap {
+        margin-top: $tp-space__2;
+    }
+}
+
 .tp-checkbox-input {
     position: absolute;
     opacity: 0;

--- a/packages/thumbprint-scss/scss/radio.scss
+++ b/packages/thumbprint-scss/scss/radio.scss
@@ -2,6 +2,17 @@
 
 .tp-radio-wrap {
     position: relative;
+
+    & .tp-label {
+        padding-left: 28px;
+        font-weight: 400;
+        cursor: pointer;
+        position: relative;
+    }
+
+    + .tp-radio-wrap {
+        margin-top: $tp-space__2;
+    }
 }
 
 .tp-radio-input {

--- a/www/src/pages/components/checkbox/scss/index.mdx
+++ b/www/src/pages/components/checkbox/scss/index.mdx
@@ -16,7 +16,7 @@ Here are a few tips for using checkboxes:
 -   The `label` and `input` are connected through the `for` and `id` attributes. Clicking on the label text should toggle the related checkbox.`
 
 ```html
-<div class="tp-input-wrap">
+<div class="tp-checkbox-wrap">
     <input
         class="tp-checkbox-input"
         name="example-basic"
@@ -27,12 +27,12 @@ Here are a few tips for using checkboxes:
     <div class="tp-checkbox-image"></div>
     <label class="tp-label" for="example-basic-a">Morning</label>
 </div>
-<div class="tp-input-wrap">
+<div class="tp-checkbox-wrap">
     <input class="tp-checkbox-input" name="example-basic" id="example-basic-b" type="checkbox" />
     <div class="tp-checkbox-image"></div>
     <label class="tp-label" for="example-basic-b">Afternoon</label>
 </div>
-<div class="tp-input-wrap">
+<div class="tp-checkbox-wrap">
     <input class="tp-checkbox-input" name="example-basic" id="example-basic-c" type="checkbox" />
     <div class="tp-checkbox-image"></div>
     <label class="tp-label" for="example-basic-c">Evening</label>
@@ -46,7 +46,7 @@ Add the `disabled` attribute to the `input` element to make it visually and func
 You should also use `tp-label--disabled` to visually disable the `label`.
 
 ```html
-<div class="tp-input-wrap">
+<div class="tp-checkbox-wrap">
     <input
         disabled
         class="tp-checkbox-input"
@@ -58,7 +58,7 @@ You should also use `tp-label--disabled` to visually disable the `label`.
     <div class="tp-checkbox-image"></div>
     <label class="tp-label tp-label--disabled" for="example-disabled-a">Morning</label>
 </div>
-<div class="tp-input-wrap">
+<div class="tp-checkbox-wrap">
     <input
         disabled
         class="tp-checkbox-input"
@@ -69,7 +69,7 @@ You should also use `tp-label--disabled` to visually disable the `label`.
     <div class="tp-checkbox-image"></div>
     <label class="tp-label tp-label--disabled" for="example-disabled-b">Afternoon</label>
 </div>
-<div class="tp-input-wrap">
+<div class="tp-checkbox-wrap">
     <input
         disabled
         class="tp-checkbox-input"
@@ -89,7 +89,7 @@ The `tp-checkbox-input--bad-news` class can be used to visually represent an err
 This class only changes the checkbox’s color. It should be used alongside an error message that helps users advance through the form.
 
 ```html
-<div class="tp-input-wrap">
+<div class="tp-checkbox-wrap">
     <input
         class="tp-checkbox-input tp-checkbox-input--bad-news"
         name="example-error"

--- a/www/src/pages/components/radio/scss/index.mdx
+++ b/www/src/pages/components/radio/scss/index.mdx
@@ -17,7 +17,7 @@ Here are a few tips for using radio buttons:
 -   The `label`’s `for` attribute must match the `id` of the associated radio. This allows users to select the radio while clicking on the `label` text.
 
 ```html
-<div class="tp-input-wrap">
+<div class="tp-radio-wrap">
     <input
         class="tp-radio-input"
         name="input-basic-radio"
@@ -28,12 +28,12 @@ Here are a few tips for using radio buttons:
     <div class="tp-radio-image"></div>
     <label class="tp-label" for="input-basic-radio-a">Long Distance Moving</label>
 </div>
-<div class="tp-input-wrap">
+<div class="tp-radio-wrap">
     <input class="tp-radio-input" name="input-basic-radio" type="radio" id="input-basic-radio-b" />
     <div class="tp-radio-image"></div>
     <label class="tp-label" for="input-basic-radio-b">Furniture Moving and Heavy Lifting</label>
 </div>
-<div class="tp-input-wrap">
+<div class="tp-radio-wrap">
     <input class="tp-radio-input" name="input-basic-radio" type="radio" id="input-basic-radio-c" />
     <div class="tp-radio-image"></div>
     <label class="tp-label" for="input-basic-radio-c">Pool Table Moving</label>
@@ -47,7 +47,7 @@ Add the `disabled` attribute to the `input` element to make it visually and func
 You should also use `tp-label--disabled` to visually disable the `label`.
 
 ```html
-<div class="tp-input-wrap">
+<div class="tp-radio-wrap">
     <input
         class="tp-radio-input"
         name="input-disabed"
@@ -59,14 +59,14 @@ You should also use `tp-label--disabled` to visually disable the `label`.
     <div class="tp-radio-image"></div>
     <label class="tp-label tp-label--disabled" for="input-disabed-a">Long Distance Moving</label>
 </div>
-<div class="tp-input-wrap">
+<div class="tp-radio-wrap">
     <input class="tp-radio-input" name="input-disabed" id="input-disabed-b" type="radio" disabled />
     <div class="tp-radio-image"></div>
     <label class="tp-label tp-label--disabled" for="input-disabed-b">
         Furniture Moving and Heavy Lifting
     </label>
 </div>
-<div class="tp-input-wrap">
+<div class="tp-radio-wrap">
     <input class="tp-radio-input" name="input-disabed" id="input-disabed-c" type="radio" disabled />
     <div class="tp-radio-image"></div>
     <label class="tp-label tp-label--disabled" for="input-disabed-c">Pool Table Moving</label>
@@ -80,7 +80,7 @@ The `tp-radio-input--bad-news` class can be used to visually represent an error.
 This class only changes the radio button’s color. It should be used alongside an error message that helps users advance through the form.
 
 ```html
-<div class="tp-input-wrap">
+<div class="tp-radio-wrap">
     <input
         class="tp-radio-input tp-radio-input--bad-news"
         name="input-error"


### PR DESCRIPTION
These will allow us to remove `tp-input-wrap`, a class in `form.scss` which is currently required to use a radio or checkbox.

Relates to #559.