### PR TITLE
Move textarea/input placeholder color code.

### DIFF
--- a/packages/thumbprint-scss/CHANGELOG.md
+++ b/packages/thumbprint-scss/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+-   [Minor] Add input placeholder text color code to `input.scss` and `textarea.scss`. These styles are duplicated in `form.scss` but that file will soon be removed. (#559)
+
 ## 3.0.0 - 2019-11-20
 
 ### Removed

--- a/packages/thumbprint-scss/__snapshots__/test.js.snap
+++ b/packages/thumbprint-scss/__snapshots__/test.js.snap
@@ -1071,6 +1071,15 @@ exports[`compiles correctly 1`] = `
   vertical-align: middle;
   line-height: 24px;
 }
+.tp-text-input::-webkit-input-placeholder {
+  color: #676d73;
+}
+.tp-text-input::-moz-placeholder {
+  color: #676d73;
+}
+.tp-text-input:-ms-input-placeholder {
+  color: #676d73;
+}
 .tp-text-input--small {
   line-height: 20px;
   padding: 9px 15px;
@@ -1590,6 +1599,15 @@ _:-ms-fullscreen {
   resize: vertical;
   height: 152px;
   min-height: 104px;
+}
+.tp-textarea::-webkit-input-placeholder {
+  color: #676d73;
+}
+.tp-textarea::-moz-placeholder {
+  color: #676d73;
+}
+.tp-textarea:-ms-input-placeholder {
+  color: #676d73;
 }
 .tp-textarea:focus {
   color: #2f3033;

--- a/packages/thumbprint-scss/scss/input.scss
+++ b/packages/thumbprint-scss/scss/input.scss
@@ -10,6 +10,18 @@
     vertical-align: middle;
     line-height: $tp-font__body__1__line-height;
 
+    &::-webkit-input-placeholder {
+        color: $tp-color__black-300;
+    }
+
+    &::-moz-placeholder {
+        color: $tp-color__black-300;
+    }
+
+    &:-ms-input-placeholder {
+        color: $tp-color__black-300;
+    }
+
     &--small {
         line-height: $tp-font__body__2__line-height;
         padding: 9px 15px;

--- a/packages/thumbprint-scss/scss/textarea.scss
+++ b/packages/thumbprint-scss/scss/textarea.scss
@@ -12,6 +12,18 @@
     height: 152px;
     min-height: 104px;
 
+    &::-webkit-input-placeholder {
+        color: $tp-color__black-300;
+    }
+
+    &::-moz-placeholder {
+        color: $tp-color__black-300;
+    }
+
+    &:-ms-input-placeholder {
+        color: $tp-color__black-300;
+    }
+
     &:focus {
         color: $tp-color__black;
         border-color: $tp-color__blue;


### PR DESCRIPTION
This will allow us to remove it from `form.scss`.

Relates to #559.