### PR TITLE
Alias Textarea as TextArea

### DIFF
--- a/packages/thumbprint-react/CHANGELOG.md
+++ b/packages/thumbprint-react/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
--   [Minor] Export a `TextInput` component that is an alias for `Input`. (#566)
+-   [Minor] Export a `TextArea` component that is an alias for `Textarea`. (#566)
 
 ## 11.0.2 - 2019-11-21
 

--- a/packages/thumbprint-react/CHANGELOG.md
+++ b/packages/thumbprint-react/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+-   [Minor] Export a `TextInput` component that is an alias for `Input`. (#566)
+
 ## 11.0.2 - 2019-11-21
 
 ### Changed

--- a/packages/thumbprint-react/components/Textarea/__snapshots__/test.tsx.snap
+++ b/packages/thumbprint-react/components/Textarea/__snapshots__/test.tsx.snap
@@ -17,6 +17,23 @@ exports[`adds \`dataTest\` prop 1`] = `
 </Textarea>
 `;
 
+exports[`adds \`dataTest\` prop 2`] = `
+<Textarea
+  dataTest="Duck"
+  onChange={[Function]}
+  value="goose"
+>
+  <textarea
+    className="root rootStateDefault"
+    data-test="Duck"
+    disabled={false}
+    onChange={[Function]}
+    required={false}
+    value="goose"
+  />
+</Textarea>
+`;
+
 exports[`adds \`disabled\` attribute 1`] = `
 <Textarea
   isDisabled={true}
@@ -33,7 +50,40 @@ exports[`adds \`disabled\` attribute 1`] = `
 </Textarea>
 `;
 
+exports[`adds \`disabled\` attribute 2`] = `
+<Textarea
+  isDisabled={true}
+  onChange={[Function]}
+  value="goose"
+>
+  <textarea
+    className="root rootStateDisabled"
+    disabled={true}
+    onChange={[Function]}
+    required={false}
+    value="goose"
+  />
+</Textarea>
+`;
+
 exports[`adds \`id\` attribute 1`] = `
+<Textarea
+  id="Goose"
+  onChange={[Function]}
+  value="goose"
+>
+  <textarea
+    className="root rootStateDefault"
+    disabled={false}
+    id="Goose"
+    onChange={[Function]}
+    required={false}
+    value="goose"
+  />
+</Textarea>
+`;
+
+exports[`adds \`id\` attribute 2`] = `
 <Textarea
   id="Goose"
   onChange={[Function]}
@@ -67,7 +117,41 @@ exports[`adds \`maxLength\` attribute 1`] = `
 </Textarea>
 `;
 
+exports[`adds \`maxLength\` attribute 2`] = `
+<Textarea
+  maxLength={100}
+  onChange={[Function]}
+  value="goose"
+>
+  <textarea
+    className="root rootStateDefault"
+    disabled={false}
+    maxLength={100}
+    onChange={[Function]}
+    required={false}
+    value="goose"
+  />
+</Textarea>
+`;
+
 exports[`adds \`name\` HTML attribute 1`] = `
+<Textarea
+  name="duck"
+  onChange={[Function]}
+  value="goose"
+>
+  <textarea
+    className="root rootStateDefault"
+    disabled={false}
+    name="duck"
+    onChange={[Function]}
+    required={false}
+    value="goose"
+  />
+</Textarea>
+`;
+
+exports[`adds \`name\` HTML attribute 2`] = `
 <Textarea
   name="duck"
   onChange={[Function]}
@@ -100,7 +184,40 @@ exports[`adds \`required\` attribute 1`] = `
 </Textarea>
 `;
 
+exports[`adds \`required\` attribute 2`] = `
+<Textarea
+  isRequired={true}
+  onChange={[Function]}
+  value="goose"
+>
+  <textarea
+    className="root rootStateDefault"
+    disabled={false}
+    onChange={[Function]}
+    required={true}
+    value="goose"
+  />
+</Textarea>
+`;
+
 exports[`adds placeholder 1`] = `
+<Textarea
+  onChange={[Function]}
+  placeholder="Goose"
+  value="goose"
+>
+  <textarea
+    className="root rootStateDefault"
+    disabled={false}
+    onChange={[Function]}
+    placeholder="Goose"
+    required={false}
+    value="goose"
+  />
+</Textarea>
+`;
+
+exports[`adds placeholder 2`] = `
 <Textarea
   onChange={[Function]}
   placeholder="Goose"
@@ -125,7 +242,31 @@ exports[`renders \`value\` as the \`value\` attribute 1`] = `
 </textarea>
 `;
 
+exports[`renders \`value\` as the \`value\` attribute 2`] = `
+<textarea
+  class="root rootStateDefault"
+>
+  Goose
+</textarea>
+`;
+
 exports[`renders an error state 1`] = `
+<Textarea
+  hasError={true}
+  onChange={[Function]}
+  value="goose"
+>
+  <textarea
+    className="root rootStateError"
+    disabled={false}
+    onChange={[Function]}
+    required={false}
+    value="goose"
+  />
+</Textarea>
+`;
+
+exports[`renders an error state 2`] = `
 <Textarea
   hasError={true}
   onChange={[Function]}

--- a/packages/thumbprint-react/components/Textarea/index.tsx
+++ b/packages/thumbprint-react/components/Textarea/index.tsx
@@ -81,7 +81,7 @@ interface PropTypes {
     dataTest?: string;
 }
 
-export default function Textarea({
+const Textarea = ({
     dataTest,
     hasError = false,
     id,
@@ -94,7 +94,7 @@ export default function Textarea({
     placeholder,
     value,
     name,
-}: PropTypes): JSX.Element {
+}: PropTypes): JSX.Element => {
     const uiState = getUIState({ hasError, isDisabled });
 
     return (
@@ -118,4 +118,7 @@ export default function Textarea({
             name={name}
         />
     );
-}
+};
+
+export { Textarea as TextArea };
+export default Textarea;

--- a/packages/thumbprint-react/components/Textarea/test.tsx
+++ b/packages/thumbprint-react/components/Textarea/test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { shallow, mount, render } from 'enzyme';
 import noop from 'lodash/noop';
-import Textarea from './index';
+import Textarea, { TextArea } from './index';
 
 test('adds placeholder', () => {
     const wrapper = mount(<Textarea placeholder="Goose" onChange={jest.fn} value="goose" />);
@@ -97,6 +97,104 @@ test('calls `onFocus` function when supplied', () => {
 
 test('adds `dataTest` prop', () => {
     const wrapper = mount(<Textarea dataTest="Duck" onChange={noop} value="goose" />);
+    expect(wrapper.find('textarea').prop('data-test')).toEqual('Duck');
+    expect(wrapper).toMatchSnapshot();
+});
+
+test('adds placeholder', () => {
+    const wrapper = mount(<TextArea placeholder="Goose" onChange={jest.fn} value="goose" />);
+    expect(wrapper.prop('placeholder')).toBe('Goose');
+    expect(wrapper).toMatchSnapshot();
+});
+
+test('renders an error state', () => {
+    const wrapper = mount(<TextArea hasError onChange={jest.fn} value="goose" />);
+    expect(wrapper).toMatchSnapshot();
+});
+
+test('adds `id` attribute', () => {
+    const wrapper = mount(<TextArea id="Goose" onChange={jest.fn} value="goose" />);
+    expect(wrapper.find('textarea').prop('id')).toBe('Goose');
+    expect(wrapper).toMatchSnapshot();
+});
+
+test('adds `disabled` attribute', () => {
+    const wrapper = mount(<TextArea isDisabled onChange={jest.fn} value="goose" />);
+    expect(wrapper.find('textarea').prop('disabled')).toBeTruthy();
+    expect(wrapper).toMatchSnapshot();
+});
+
+test('adds `required` attribute', () => {
+    const wrapper = mount(<TextArea isRequired onChange={jest.fn} value="goose" />);
+    expect(wrapper.find('textarea').prop('required')).toBeTruthy();
+    expect(wrapper).toMatchSnapshot();
+});
+
+test('adds `maxLength` attribute', () => {
+    const wrapper = mount(<TextArea maxLength={100} onChange={jest.fn} value="goose" />);
+    expect(wrapper.prop('maxLength')).toBe(100);
+    expect(wrapper).toMatchSnapshot();
+});
+
+test('adds `name` HTML attribute', () => {
+    const wrapperA = mount(<TextArea name="duck" onChange={noop} value="goose" />);
+    expect(wrapperA.find('textarea').prop('name')).toEqual('duck');
+    expect(wrapperA).toMatchSnapshot();
+});
+
+test('renders `value` as the `value` attribute', () => {
+    const wrapper = render(<TextArea value="Goose" onChange={jest.fn} />);
+    expect(wrapper.text()).toBe('Goose');
+    expect(wrapper).toMatchSnapshot();
+});
+
+test('calls `onChange` function and passes value', () => {
+    const onChange = jest.fn();
+
+    const wrapper = mount(<TextArea onChange={onChange} value="goose" />);
+
+    const firstEvent = { target: { value: 'He' } };
+    const secondEvent = { target: { value: 'Hello' } };
+
+    wrapper.find('textarea').simulate('change', firstEvent);
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenLastCalledWith(
+        firstEvent.target.value,
+        expect.objectContaining({
+            target: expect.any(Object),
+        }),
+    );
+
+    wrapper.find('textarea').simulate('change', secondEvent);
+    expect(onChange).toHaveBeenCalledTimes(2);
+    expect(onChange).toHaveBeenLastCalledWith(
+        secondEvent.target.value,
+        expect.objectContaining({
+            target: expect.any(Object),
+        }),
+    );
+});
+
+test('calls `onBlur` function when supplied', () => {
+    const onBlur = jest.fn();
+
+    const wrapper = shallow(<TextArea onBlur={onBlur} onChange={jest.fn} value="goose" />);
+
+    wrapper.simulate('blur');
+    expect(onBlur).toHaveBeenCalledTimes(1);
+});
+
+test('calls `onFocus` function when supplied', () => {
+    const onFocus = jest.fn();
+
+    const wrapper = shallow(<TextArea onFocus={onFocus} onChange={jest.fn} value="goose" />);
+
+    wrapper.simulate('focus');
+    expect(onFocus).toHaveBeenCalledTimes(1);
+});
+
+test('adds `dataTest` prop', () => {
+    const wrapper = mount(<TextArea dataTest="Duck" onChange={noop} value="goose" />);
     expect(wrapper.find('textarea').prop('data-test')).toEqual('Duck');
     expect(wrapper).toMatchSnapshot();
 });

--- a/packages/thumbprint-react/index.ts
+++ b/packages/thumbprint-react/index.ts
@@ -45,7 +45,7 @@ export {
     ServiceCardImage,
 } from './components/ServiceCard/index';
 export { default as StarRating } from './components/StarRating/index';
-export { default as Textarea } from './components/Textarea/index';
+export { default as Textarea, TextArea } from './components/Textarea/index';
 export { default as Tooltip } from './components/Tooltip/index';
 export { Title, Text } from './components/Type/index';
 export { default as Wrap } from './components/Wrap/index';


### PR DESCRIPTION
How this was done:

1. Create new exports in the component file that uses the new names. This PR doesn't include directory or variable renames.
2. Duplicate the tests in the component's test file and use the new component names in the duplicated tests.
3. Export the new component names in the root index file.

Since the snapshot file only has additions, we can be confident that this is not a breaking change. This relates to #566.