### PR TITLE
Upgrade node version

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/carbon
+lts/erbium


### PR DESCRIPTION
The Node v8 LTS ends Dec. 31.

Node v12 is the newest LTS and ends in 2022.