### PR TITLE
Change UserAvatar, EntityAvatar Empty Background Color

### DIFF
--- a/packages/thumbprint-react/CHANGELOG.md
+++ b/packages/thumbprint-react/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changed
 
 -   [Patch] Replace existing duration and easing values for SCSS/JS tokens in `Modal`.
+-   [Patch] Change `EntityAvatar`, `UserAvatar` empty background color from `gray-200` to `gray`.
 
 ## 12.0.0 - 2019-12-17
 

--- a/packages/thumbprint-react/components/Avatar/__snapshots__/test.tsx.snap
+++ b/packages/thumbprint-react/components/Avatar/__snapshots__/test.tsx.snap
@@ -144,7 +144,7 @@ exports[`adds the \`fullName\` as \`title\` text 1`] = `
       className="initialsAvatar circleAvatar"
       style={
         Object {
-          "backgroundColor": "#fafafa",
+          "backgroundColor": "#d3d4d5",
           "color": "#2f3033",
         }
       }
@@ -251,7 +251,7 @@ exports[`does not add the \`fullName\` as \`alt\` text when no image is provided
       className="initialsAvatar circleAvatar"
       style={
         Object {
-          "backgroundColor": "#fafafa",
+          "backgroundColor": "#d3d4d5",
           "color": "#2f3033",
         }
       }
@@ -335,7 +335,7 @@ exports[`renders \`isOnline\` when \`isOnline\` is true 1`] = `
       className="initialsAvatar circleAvatar"
       style={
         Object {
-          "backgroundColor": "#fafafa",
+          "backgroundColor": "#d3d4d5",
           "color": "#2f3033",
         }
       }
@@ -704,7 +704,7 @@ exports[`renders checkmark SVG when \`isChecked\` and \`isOnline\` are true 1`] 
       className="initialsAvatar circleAvatar"
       style={
         Object {
-          "backgroundColor": "#fafafa",
+          "backgroundColor": "#d3d4d5",
           "color": "#2f3033",
         }
       }

--- a/packages/thumbprint-react/components/Avatar/index.tsx
+++ b/packages/thumbprint-react/components/Avatar/index.tsx
@@ -58,7 +58,7 @@ const STYLES: StyleType[] = [
 const getStyle = (initials?: string): StyleType =>
     initials
         ? STYLES[initials.charCodeAt(0) % STYLES.length]
-        : { color: tokens.tpColorBlack, backgroundColor: tokens.tpColorGray200 };
+        : { color: tokens.tpColorBlack, backgroundColor: tokens.tpColorGray };
 
 const EntityAvatar = forwardRef<HTMLElement, EntityPropTypes>(
     (props: EntityPropTypes, outerRef): JSX.Element => {


### PR DESCRIPTION
There exists a case in the Avatar Upload component where
the Avatar empty state background matches the page background.

According to designs, the Avatar empty background color should
be `gray`, not `gray-200` (which matches the page bg color).

Therefore, change the Avatar background default color to `gray`.

https://thumbtack.atlassian.net/browse/PROG-2126

![image](https://user-images.githubusercontent.com/34253100/71856946-80124800-309a-11ea-83fc-a2c08f77b111.png)
