### PR TITLE
Fix page header in CMS component pages

### DIFF
--- a/www/src/components/cms/index.jsx
+++ b/www/src/components/cms/index.jsx
@@ -4,11 +4,11 @@ import { graphql } from 'gatsby';
 import MDX from '../mdx';
 import { ComponentHeader } from '../thumbprint-components';
 
-const CMS = ({ data, location, isComponent }) => (
+const CMS = ({ data, location, pageContext }) => (
     <MDX
         location={location}
         pageContext={{ frontmatter: data.mdx.frontmatter }}
-        header={isComponent && data.platformNav && <ComponentHeader data={data} />}
+        header={pageContext.isComponent && data.platformNav && <ComponentHeader data={data} />}
     >
         {data.mdx.body}
     </MDX>
@@ -17,11 +17,7 @@ const CMS = ({ data, location, isComponent }) => (
 CMS.propTypes = {
     data: PropTypes.shape({}).isRequired,
     location: PropTypes.string.isRequired,
-    isComponent: PropTypes.bool,
-};
-
-CMS.defaultProps = {
-    isComponent: false,
+    pageContext: PropTypes.shape({}).isRequired,
 };
 
 export default CMS;


### PR DESCRIPTION
Currently the platform header is missing from component pages that are using the CMS. This brings it back so that users can switch platforms.