### PR TITLE
Remove rename notices from component docs

### DIFF
--- a/www/src/pages/components/calendar/react/index.mdx
+++ b/www/src/pages/components/calendar/react/index.mdx
@@ -5,16 +5,8 @@ description: Configurable date selector.
 
 import { graphql } from 'gatsby';
 import { ComponentHeader, ComponentFooter } from 'components/thumbprint-components';
-import Alert from 'components/alert';
-import { InlineCode } from 'components/mdx';
 
 <ComponentHeader data={props.data} />
-
-<Alert type="warning" title="This component was recently renamed">
-    The <InlineCode>Calendar</InlineCode> React component component was recently renamed from{' '}
-    <InlineCode>DatePicker</InlineCode>.
-    <a href="https://github.com/thumbtack/thumbprint/issues/566">Learn more about the changes</a>.
-</Alert>
 
 ## Initial dates
 

--- a/www/src/pages/components/dropdown/react/index.mdx
+++ b/www/src/pages/components/dropdown/react/index.mdx
@@ -5,16 +5,8 @@ description: Dropdown for selecting an item from a larger set.
 
 import { graphql } from 'gatsby';
 import { ComponentHeader, ComponentFooter } from 'components/thumbprint-components';
-import Alert from 'components/alert';
-import { InlineCode } from 'components/mdx';
 
 <ComponentHeader data={props.data} />
-
-<Alert type="warning" title="This component was recently renamed">
-    The <InlineCode>Dropdown</InlineCode> React component component was recently renamed from{' '}
-    <InlineCode>Select</InlineCode>.
-    <a href="https://github.com/thumbtack/thumbprint/issues/566">Learn more about the changes</a>.
-</Alert>
 
 ## Dropdown with state management
 

--- a/www/src/pages/components/dropdown/scss/index.mdx
+++ b/www/src/pages/components/dropdown/scss/index.mdx
@@ -5,16 +5,8 @@ description: Dropdown for selecting an item from a larger set.
 
 import { graphql } from 'gatsby';
 import { ComponentHeader, ComponentFooter } from 'components/thumbprint-components';
-import Alert from 'components/alert';
-import { InlineCode } from 'components/mdx';
 
 <ComponentHeader data={props.data} />
-
-<Alert type="warning" title="This component will be renamed">
-    The <InlineCode>tp-select</InlineCode> classes component will be renamed to{' '}
-    <InlineCode>tp-dropdown</InlineCode> in early December.
-    <a href="https://github.com/thumbtack/thumbprint/issues/566">Learn more about the changes</a>.
-</Alert>
 
 ## Dropdown sizes
 

--- a/www/src/pages/components/horizontal-rule/scss/index.mdx
+++ b/www/src/pages/components/horizontal-rule/scss/index.mdx
@@ -5,16 +5,8 @@ description: Dividers that separate sections of content.
 
 import { graphql } from 'gatsby';
 import { ComponentHeader, ComponentFooter } from 'components/thumbprint-components';
-import Alert from 'components/alert';
-import { InlineCode } from 'components/mdx';
 
 <ComponentHeader data={props.data} />
-
-<Alert type="warning" title="This component will be renamed">
-    The <InlineCode>tp-rule</InlineCode> classes will be renamed to{' '}
-    <InlineCode>tp-horizontal-rule</InlineCode> in early December.
-    <a href="https://github.com/thumbtack/thumbprint/issues/566">Learn more about the changes</a>.
-</Alert>
 
 ## Horizontal Rule Styles
 

--- a/www/src/pages/components/loader-dots/scss/index.mdx
+++ b/www/src/pages/components/loader-dots/scss/index.mdx
@@ -5,16 +5,8 @@ description: Loading indicator with three animated dots.
 
 import { graphql } from 'gatsby';
 import { ComponentHeader, ComponentFooter } from 'components/thumbprint-components';
-import Alert from 'components/alert';
-import { InlineCode } from 'components/mdx';
 
 <ComponentHeader data={props.data} />
-
-<Alert type="warning" title="This component will be renamed">
-    The <InlineCode>tp-loader</InlineCode> classes will be renamed to{' '}
-    <InlineCode>tp-loader-dots</InlineCode> in early December.
-    <a href="https://github.com/thumbtack/thumbprint/issues/566">Learn more about the changes</a>.
-</Alert>
 
 ## Loader Sizes
 

--- a/www/src/pages/components/modal/react/index.mdx
+++ b/www/src/pages/components/modal/react/index.mdx
@@ -6,15 +6,8 @@ description: A basic and commonly used modal.
 import { graphql } from 'gatsby';
 import { ComponentHeader, ComponentFooter } from 'components/thumbprint-components';
 import Alert from 'components/alert';
-import { InlineCode } from 'components/mdx';
 
 <ComponentHeader data={props.data} />
-
-<Alert type="warning" title="This component was recently renamed">
-    The <InlineCode>Modal</InlineCode> React component component was recently renamed from{' '}
-    <InlineCode>ModalDefault</InlineCode>.
-    <a href="https://github.com/thumbtack/thumbprint/issues/566">Learn more about the changes</a>.
-</Alert>
 
 ## Modal variations
 

--- a/www/src/pages/components/text-area/react/index.mdx
+++ b/www/src/pages/components/text-area/react/index.mdx
@@ -5,16 +5,8 @@ description: Multiline inputs for text.
 
 import { graphql } from 'gatsby';
 import { ComponentHeader, ComponentFooter } from 'components/thumbprint-components';
-import Alert from 'components/alert';
-import { InlineCode } from 'components/mdx';
 
 <ComponentHeader data={props.data} />
-
-<Alert type="warning" title="This component was recently renamed">
-    The <InlineCode>TextArea</InlineCode> React component component was recently renamed from{' '}
-    <InlineCode>Textarea</InlineCode>.
-    <a href="https://github.com/thumbtack/thumbprint/issues/566">Learn more about the changes</a>.
-</Alert>
 
 ## Basic Text Area
 

--- a/www/src/pages/components/text-area/scss/index.mdx
+++ b/www/src/pages/components/text-area/scss/index.mdx
@@ -5,16 +5,8 @@ description: Multiline inputs for text.
 
 import { graphql } from 'gatsby';
 import { ComponentHeader, ComponentFooter } from 'components/thumbprint-components';
-import Alert from 'components/alert';
-import { InlineCode } from 'components/mdx';
 
 <ComponentHeader data={props.data} />
-
-<Alert type="warning" title="This component will be renamed">
-    The <InlineCode>tp-textarea</InlineCode> classes will be renamed to{' '}
-    <InlineCode>tp-text-area</InlineCode> in early December.
-    <a href="https://github.com/thumbtack/thumbprint/issues/566">Learn more about the changes</a>.
-</Alert>
 
 ## Basic Text Area example
 

--- a/www/src/pages/components/text-input/react/index.mdx
+++ b/www/src/pages/components/text-input/react/index.mdx
@@ -5,16 +5,8 @@ description: Form inputs with sizes and style variations.
 
 import { graphql } from 'gatsby';
 import { ComponentHeader, ComponentFooter } from 'components/thumbprint-components';
-import Alert from 'components/alert';
-import { InlineCode } from 'components/mdx';
 
 <ComponentHeader data={props.data} />
-
-<Alert type="warning" title="This component was recently renamed">
-    The <InlineCode>TextInput</InlineCode> React component component was recently renamed from{' '}
-    <InlineCode>Input</InlineCode>.
-    <a href="https://github.com/thumbtack/thumbprint/issues/566">Learn more about the changes</a>.
-</Alert>
 
 ## TextInput with an icon and clear button
 


### PR DESCRIPTION
This removes it from the React and the SCSS component docs.

The React ones can be removed because the migration is complete.

I never ended up actually starting the SCSS name changes. I propose that we leave the old classes as-is and revisit the rename migration for that in the future. It's high effort and low impact IMO.