### PR TITLE
Use consistent format for package.json author data

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,11 +89,7 @@
         "ui-library",
         "design-system"
     ],
-    "author": {
-        "name": "Tom Genoni",
-        "email": "tom@atomeye.com",
-        "url": "http://atomeye.com/"
-    },
+    "author": "Tom Genoni <tom@thumbtack.com>",
     "contributors": [
         {
             "name": "Daniel O'Connor",

--- a/packages/thumbprint-codemods/CHANGELOG.md
+++ b/packages/thumbprint-codemods/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changed
 
 -   [Patch] Upgrade jscodeshift from `0.6.4` to `0.7.0`.
+-   [Patch] Change the formatting in the `package.json` field.
 
 ## 0.4.0 - 2019-12-05
 

--- a/packages/thumbprint-codemods/package.json
+++ b/packages/thumbprint-codemods/package.json
@@ -12,11 +12,7 @@
         "registry": "https://registry.npmjs.org/",
         "access": "public"
     },
-    "author": {
-        "name": "Daniel O'Connor",
-        "email": "daniel@danoc.me",
-        "url": "https://danoc.me/"
-    },
+    "author": "Daniel O'Connor <doconnor@thumbtack.com>",
     "license": "Apache-2.0",
     "engines": {
         "node": ">=8"

--- a/packages/thumbprint-font-face/CHANGELOG.md
+++ b/packages/thumbprint-font-face/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Changed
 
 -   [Patch] Update version of the Thumbprint Tokens dependency.
+-   [Patch] Change the formatting in the `package.json` field.
 
 ## 1.0.12 - 2019-09-17
 

--- a/packages/thumbprint-font-face/package.json
+++ b/packages/thumbprint-font-face/package.json
@@ -10,11 +10,7 @@
         "registry": "https://registry.npmjs.org/",
         "access": "public"
     },
-    "author": {
-        "name": "Tom Genoni",
-        "email": "tom@atomeye.com",
-        "url": "http://atomeye.com/"
-    },
+    "author": "Daniel O'Connor <doconnor@thumbtack.com>",
     "contributors": [
         {
             "name": "Daniel O'Connor",

--- a/packages/thumbprint-react/CHANGELOG.md
+++ b/packages/thumbprint-react/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 -   [Patch] Refactored `StarRating` to output less HTML, add accessibility.
+-   [Patch] Change the formatting in the `package.json` field.
 
 ### Added
 

--- a/packages/thumbprint-react/package.json
+++ b/packages/thumbprint-react/package.json
@@ -28,11 +28,7 @@
         "registry": "https://registry.npmjs.org/",
         "access": "public"
     },
-    "author": {
-        "name": "Daniel O'Connor",
-        "email": "daniel@danoc.me",
-        "url": "https://danoc.me/"
-    },
+    "author": "Daniel O'Connor <doconnor@thumbtack.com>",
     "license": "Apache-2.0",
     "bugs": {
         "url": "https://github.com/thumbtack/thumbprint/issues"


### PR DESCRIPTION
Gatsby pulls in the `package.json` so that it can be queried for use within the documentation. It was throwing a warning about the `author` data because it was an object in some places and a string in others. This doesn't work because values within GraphQL must share the same type. Changing all of them to a string is an easy fix to remove some of the warnings.

Relates to #336.