### PR TITLE
Change type of some JSDoc to fix warning

### DIFF
--- a/packages/thumbprint-react/CHANGELOG.md
+++ b/packages/thumbprint-react/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+-   [Patch] Change some JSDoc annotations to please Gatsby
 -   [Patch] Refactored `StarRating` to output less HTML, add accessibility.
 -   [Patch] Change the formatting in the `package.json` field.
 

--- a/packages/thumbprint-react/components/Avatar/index.tsx
+++ b/packages/thumbprint-react/components/Avatar/index.tsx
@@ -198,7 +198,7 @@ interface UserPropTypes {
     size?: 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge' | number;
     /**
      * Displays a badge of a checkmark next to the `Avatar`.
-     * @deprecated
+     * @deprecated Indicate this information outside of the avatar instead.
      */
     isChecked?: boolean;
     /**

--- a/packages/thumbprint-react/components/TextInput/index.tsx
+++ b/packages/thumbprint-react/components/TextInput/index.tsx
@@ -51,7 +51,6 @@ interface InputIconContainerPropTypes {
  * classes to position the icon. It does this by using `create-react-context`, a ponyfill for
  * React’s context functionality. This makes it easier for consumers to use `InputClearButton` and
  * `InputIcon` because they won’t have to specify as many props.
- * @private
  */
 const TextInputIconContainer = ({ children, style }: InputIconContainerPropTypes): JSX.Element => (
     <Context.Consumer>
@@ -119,7 +118,6 @@ const TextInputClearButton = ({ onClick }: TextInputClearButtonPropTypes): JSX.E
 interface TextInputIconPropTypes {
     /**
      * Set the icon color with a color from [Thumbprint Tokens](/tokens/).
-     * @private
      */
     color?: string;
     /**


### PR DESCRIPTION
Gatsby's `react-docgen` plugin was upset that `@private` and `@deprecated` had inconsistent value types (booleans and strings). This removes `@private` (the docs weren't actually using that) and adds a deprecation message to the `@deprecated` that didn't have a message.

Relates to #336