### PR TITLE
Fixing minor Chrome flicker bug with example

### DIFF
--- a/www/src/components/motion/general/scale/index.module.scss
+++ b/www/src/components/motion/general/scale/index.module.scss
@@ -18,7 +18,7 @@
 
 .image {
     background: url(./training.jpg);
-    background-size: cover;
+    background-size: 144%;
     background-position: right;
     height: 100px;
 }


### PR DESCRIPTION
The background image in this example flickers a bit on hover of a sibling example in Chrome only. This prevents it. 