### PR TITLE
Make `Image` work with new version of dep

### DIFF
--- a/packages/thumbprint-react/CHANGELOG.md
+++ b/packages/thumbprint-react/CHANGELOG.md
@@ -8,6 +8,10 @@
 -   [Patch] Rewrite `Pill` component in TypeScript.
 -   [Patch] Rewrite `InputRow` component in TypeScript.
 
+### Fixed
+
+-   [Patch] Re-write ref handling in `Image` component so it works with a change in `react-intersection-observer@8.24.1`.
+
 ## 12.1.0 - 2020-01-09
 
 ### Changed

--- a/packages/thumbprint-react/components/Image/index.tsx
+++ b/packages/thumbprint-react/components/Image/index.tsx
@@ -135,8 +135,6 @@ const Image = forwardRef<HTMLElement, ImagePropTypes>((props: ImagePropTypes, ou
         triggerOnce: true,
     });
 
-    console.log('RENDER');
-
     const [browserSupportIntersectionObserver, setBrowserSupportIntersectionObserver] = useState(
         canUseDOM && typeof window.IntersectionObserver !== 'undefined',
     );
@@ -234,6 +232,12 @@ const Image = forwardRef<HTMLElement, ImagePropTypes>((props: ImagePropTypes, ou
     const [isLoaded, setIsLoaded] = useState(false);
     const [isError, setIsError] = useState(false);
 
+    // --------------------------------------------------------------------------------------------
+    // Combining refs: This component has three refs that need to be combined into one. This
+    // method of combining refs is suggested by `react-intersection-observer`:
+    // https://github.com/thebuilder/react-intersection-observer#how-can-i-assign-multiple-refs-to-a-component
+    // --------------------------------------------------------------------------------------------
+
     const setRefs = useCallback(
         node => {
             // Using a callback `ref` on this `picture` allows us to have multiple `ref`s on one
@@ -250,7 +254,7 @@ const Image = forwardRef<HTMLElement, ImagePropTypes>((props: ImagePropTypes, ou
                 outerRef(node);
             }
         },
-        [inViewRef, outerRef, browserSupportIntersectionObserver],
+        [inViewRef, outerRef, setContainerRef, browserSupportIntersectionObserver],
     );
 
     return (

--- a/packages/thumbprint-react/components/Image/index.tsx
+++ b/packages/thumbprint-react/components/Image/index.tsx
@@ -244,7 +244,8 @@ const Image = forwardRef<HTMLElement, ImagePropTypes>((props: ImagePropTypes, ou
             // element.
             setContainerRef(node);
 
-            // Callback refs, like the one from `useInView`, is a function that takes the node as an argument
+            // We don't want to turn on the `react-intersection-observer` functionality until
+            // the polyfill is done loading.
             if (browserSupportIntersectionObserver) {
                 inViewRef(node);
             }

--- a/packages/thumbprint-react/package.json
+++ b/packages/thumbprint-react/package.json
@@ -47,7 +47,7 @@
         "object-fit-images": "^3.2.4",
         "react-day-picker": "7.3.2",
         "react-displace": "^2.3.0",
-        "react-intersection-observer": "^8.23.0",
+        "react-intersection-observer": "^8.25.2",
         "react-onclickoutside": "^6.4.0",
         "react-popper": "^1.0.0",
         "react-swipeable": "^4.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15716,13 +15716,12 @@ react-input-autosize@^2.2.1:
   dependencies:
     prop-types "^15.5.8"
 
-react-intersection-observer@^8.23.0:
-  version "8.23.0"
-  resolved "https://registry.yarnpkg.com/react-intersection-observer/-/react-intersection-observer-8.23.0.tgz#1533aaf39cc70300ff8ca37e6551d2d68a589cd0"
-  integrity sha512-kHXfxhGKvVDNkrvmh9CKCnAWvJBigyB7oSDzMXL54weFDwwI4WfTr58YauZ0RRPkGzoD/hYEuzfS1wipXn23fA==
+react-intersection-observer@^8.25.2:
+  version "8.25.2"
+  resolved "https://registry.yarnpkg.com/react-intersection-observer/-/react-intersection-observer-8.25.2.tgz#be165f4827dc8f1927ab68ecb837efe913d94909"
+  integrity sha512-KymKTOQK0TxQFW/Km80oS8VVOZAX8nt74fsYEGw6pqBLSJlqBXEhdFpyPcBa08GiGnup8lrFRkSY4JioP+pqww==
   dependencies:
-    "@babel/runtime" "^7.0.0"
-    invariant "^2.2.4"
+    tiny-invariant "^1.0.6"
 
 react-is@16.12.0:
   version "16.12.0"
@@ -18633,7 +18632,7 @@ timsort@^0.3.0:
   resolved "https://registry.yarnpkg.com/timsort/-/timsort-0.3.0.tgz#405411a8e7e6339fe64db9a234de11dc31e02bd4"
   integrity sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=
 
-tiny-invariant@^1.0.1, tiny-invariant@^1.0.2:
+tiny-invariant@^1.0.1, tiny-invariant@^1.0.2, tiny-invariant@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.0.6.tgz#b3f9b38835e36a41c843a3b0907a5a7b3755de73"
   integrity sha512-FOyLWWVjG+aC0UqG76V53yAWdXfH8bO6FNmyZOuUrzDzK8DI3/JRY25UD7+g49JWM1LXwymsKERB+DzI0dTEQA==


### PR DESCRIPTION
The `Image` component was infinitely re-rendering with `react-intersection-observer@8.24.1`. It did not have this version with `v8.23.0`, the previous version.

I think the the issue happened because of this change: https://github.com/thebuilder/react-intersection-observer/commit/b31487b0c796cf35ecd3faaaa61da743a6abe9a2

This PR changes how we we combine multiple refs into one, following a suggestion in the `react-intersection-observer` README. This fixes the infinite re-render issue, although I'm still trying to understand why.