### PR TITLE
Remove notice from Android tokens and clean imports

### DIFF
--- a/www/src/pages/tokens/android/index.mdx
+++ b/www/src/pages/tokens/android/index.mdx
@@ -3,13 +3,10 @@ title: Tokens
 description: Design variables that power Thumbtack’s UI.
 ---
 
-import classNames from 'classnames';
-import { camelCase } from 'lodash';
 import { graphql } from 'gatsby';
 import PackageTable from 'components/package-table';
 import TabNav from 'components/thumbprint-tokens/tab-nav';
 import TokenSection from 'components/thumbprint-tokens/token-section';
-import Alert from 'components/alert';
 
 export const pageQuery = graphql`
     {
@@ -47,11 +44,6 @@ export const pageQuery = graphql`
     platform="android"
     importStatement="import com.github.thumbtack.thumbprinttokens.R"
 />
-
-<Alert type="warning" title="Not yet available in Thumbtack's Android codebase">
-    The Design Systems team is working with Thumbtack's Android engineers to install this library in
-    the Android codebase.
-</Alert>
 
 <div>
     {props.data.thumbprintToken.categories.map(section => (

--- a/www/src/pages/tokens/ios/index.mdx
+++ b/www/src/pages/tokens/ios/index.mdx
@@ -3,8 +3,6 @@ title: Tokens
 description: Design variables that power Thumbtack’s UI.
 ---
 
-import classNames from 'classnames';
-import { camelCase } from 'lodash';
 import { graphql } from 'gatsby';
 import PackageTable from 'components/package-table';
 import TabNav from 'components/thumbprint-tokens/tab-nav';

--- a/www/src/pages/tokens/javascript/index.mdx
+++ b/www/src/pages/tokens/javascript/index.mdx
@@ -3,8 +3,6 @@ title: Tokens
 description: Design variables that power Thumbtack’s UI.
 ---
 
-import classNames from 'classnames';
-import { camelCase } from 'lodash';
 import { graphql } from 'gatsby';
 import PackageTable from 'components/package-table';
 import TabNav from 'components/thumbprint-tokens/tab-nav';

--- a/www/src/pages/tokens/scss/index.mdx
+++ b/www/src/pages/tokens/scss/index.mdx
@@ -3,7 +3,6 @@ title: Tokens
 description: Design variables that power Thumbtack’s UI.
 ---
 
-import classNames from 'classnames';
 import { graphql } from 'gatsby';
 import PackageTable from 'components/package-table';
 import TabNav from 'components/thumbprint-tokens/tab-nav';


### PR DESCRIPTION
The tokens are now available for Android. This also removes unused imports on the tokens pages for other platforms.