### PR TITLE
Fix tokens page

### DIFF
--- a/www/src/components/thumbprint-tokens/token-section/index.jsx
+++ b/www/src/components/thumbprint-tokens/token-section/index.jsx
@@ -68,7 +68,10 @@ const TokenSection = ({ section, platform }) => {
                                                     <td className="tr pv2">
                                                         <TokenExample
                                                             format={token.format}
-                                                            data={token.platforms.javascript.value}
+                                                            exampleData={
+                                                                token.platforms.javascript &&
+                                                                token.platforms.javascript.value
+                                                            }
                                                             displayText={tokenPlatformValues.value}
                                                         />
                                                     </td>

--- a/www/src/components/thumbprint-tokens/token-section/token-example/index.jsx
+++ b/www/src/components/thumbprint-tokens/token-section/token-example/index.jsx
@@ -3,41 +3,38 @@ import PropTypes from 'prop-types';
 import className from 'classnames';
 import { InlineCode } from '../../../mdx';
 
-const TokenExample = ({ data, displayText, format }) => {
+const TokenExample = ({ exampleData, displayText, format }) => {
     const shouldRenderAsTwoLines = displayText.length > 30;
     let children;
 
-    switch (format) {
-        case 'color':
-            children = (
-                <table className="w-100">
-                    <tbody>
-                        <tr>
-                            <td
+    if (exampleData && format === 'color') {
+        children = (
+            <table className="w-100">
+                <tbody>
+                    <tr>
+                        <td
+                            className={className({
+                                flex: true,
+                                'tr items-center justify-end': !shouldRenderAsTwoLines,
+                                'flex-column items-end black-300': shouldRenderAsTwoLines,
+                            })}
+                        >
+                            <div
                                 className={className({
-                                    flex: true,
-                                    'tr items-center justify-end': !shouldRenderAsTwoLines,
-                                    'flex-column items-end black-300': shouldRenderAsTwoLines,
+                                    'h2 w4 ba b-gray-300': true,
+                                    mr4: !shouldRenderAsTwoLines,
+                                    mb1: shouldRenderAsTwoLines,
                                 })}
-                            >
-                                <div
-                                    className={className({
-                                        'h2 w4 ba b-gray-300': true,
-                                        mr4: !shouldRenderAsTwoLines,
-                                        mb1: shouldRenderAsTwoLines,
-                                    })}
-                                    style={{ backgroundColor: data }}
-                                />
-                                <InlineCode theme="plain">{displayText}</InlineCode>
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
-            );
-            break;
-        default:
-            children = <InlineCode theme="plain">{displayText}</InlineCode>;
-            break;
+                                style={{ backgroundColor: exampleData }}
+                            />
+                            <InlineCode theme="plain">{displayText}</InlineCode>
+                        </td>
+                    </tr>
+                </tbody>
+            </table>
+        );
+    } else {
+        children = <InlineCode theme="plain">{displayText}</InlineCode>;
     }
 
     return <div>{children}</div>;
@@ -45,12 +42,13 @@ const TokenExample = ({ data, displayText, format }) => {
 
 TokenExample.propTypes = {
     format: PropTypes.string,
-    data: PropTypes.string.isRequired,
+    exampleData: PropTypes.string,
     displayText: PropTypes.node.isRequired,
 };
 
 TokenExample.defaultProps = {
     format: undefined,
+    exampleData: undefined,
 };
 
 export default TokenExample;


### PR DESCRIPTION
The tokens pages used to make the assumption that each iOS, Sass, and Android token would also have a JavaScript equivalent. This is no longer true.

(The JavaScript value is currently used on the iOS and Android tokens documentation pages to show color examples since JavaScript values can be rendered on the web whereas UIColor would have to be converted.)

This also renames `data` to `exampleData` so that it's more clear that the value passed in is used to render an example of the token.