### PR TITLE
Set up GitHub actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,80 @@
+name: Test
+
+on: [push]
+
+jobs:
+    jest:
+        name: Test (Jest)
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@master
+            - name: Use Node.js 12.x
+              uses: actions/setup-node@v1
+              with:
+                  node-version: 12.x
+            - name: Install dependencies
+              run: |
+                  yarn install --frozen-lockfile
+            - name: Run ESLint
+              run: |
+                  yarn run bootstrap && yarn run test:jest
+    eslint:
+        name: Test (ESLint)
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@master
+            - name: Use Node.js 12.x
+              uses: actions/setup-node@v1
+              with:
+                  node-version: 12.x
+            - name: Install dependencies
+              run: |
+                  yarn install --frozen-lockfile
+            - name: Run ESLint
+              run: |
+                  yarn run bootstrap && yarn run test:lint:js
+    stylelint:
+        name: Test (stylelint)
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@master
+            - name: Use Node.js 12.x
+              uses: actions/setup-node@v1
+              with:
+                  node-version: 12.x
+            - name: Install dependencies
+              run: |
+                  yarn install --frozen-lockfile
+            - name: Run ESLint
+              run: |
+                  yarn run bootstrap && yarn run test:lint:css
+    prettier:
+        name: Test (Prettier)
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@master
+            - name: Use Node.js 12.x
+              uses: actions/setup-node@v1
+              with:
+                  node-version: 12.x
+            - name: Install dependencies
+              run: |
+                  yarn install --frozen-lockfile
+            - name: Run ESLint
+              run: |
+                  yarn run bootstrap && yarn run test:prettier
+    typescript:
+        name: Test (TypeScript)
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@master
+            - name: Use Node.js 12.x
+              uses: actions/setup-node@v1
+              with:
+                  node-version: 12.x
+            - name: Install dependencies
+              run: |
+                  yarn install --frozen-lockfile
+            - name: Run ESLint
+              run: |
+                  yarn run bootstrap && yarn run test:typecheck

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
               run: |
                   yarn run bootstrap && yarn run test:lint:js
     stylelint:
-        name: stylelint
+        name: Stylelint
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@master

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
     jest:
-        name: Test (Jest)
+        name: Jest
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@master
@@ -19,7 +19,7 @@ jobs:
               run: |
                   yarn run bootstrap && yarn run test:jest
     eslint:
-        name: Test (ESLint)
+        name: ESLint
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@master
@@ -34,7 +34,7 @@ jobs:
               run: |
                   yarn run bootstrap && yarn run test:lint:js
     stylelint:
-        name: Test (stylelint)
+        name: stylelint
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@master
@@ -49,7 +49,7 @@ jobs:
               run: |
                   yarn run bootstrap && yarn run test:lint:css
     prettier:
-        name: Test (Prettier)
+        name: Prettier
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@master
@@ -64,7 +64,7 @@ jobs:
               run: |
                   yarn run bootstrap && yarn run test:prettier
     typescript:
-        name: Test (TypeScript)
+        name: TypeScript
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@master


### PR DESCRIPTION
Testing this out as a replacement to Travis. A few benefits:

1. Seems to run a bit faster.
2. Each test appears separately and can run independently. (Previously, the Prettier check wouldn't run, for example, if an earlier test had failed.)
3. We can customize the name of the tests in the UI.
4. It's all within the GitHub UI. We can see test results without leaving the site.