### PR TITLE
Fix mistakes in GitHub actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
             - name: Install dependencies
               run: |
                   yarn install --frozen-lockfile
-            - name: Run ESLint
+            - name: Run Jest
               run: |
                   yarn run bootstrap && yarn run test:jest
     eslint:
@@ -32,7 +32,7 @@ jobs:
                   yarn install --frozen-lockfile
             - name: Run ESLint
               run: |
-                  yarn run bootstrap && yarn run test:lint:js
+                  yarn run test:lint:js
     stylelint:
         name: Stylelint
         runs-on: ubuntu-latest
@@ -45,9 +45,9 @@ jobs:
             - name: Install dependencies
               run: |
                   yarn install --frozen-lockfile
-            - name: Run ESLint
+            - name: Run Stylelint
               run: |
-                  yarn run bootstrap && yarn run test:lint:css
+                  yarn run test:lint:css
     prettier:
         name: Prettier
         runs-on: ubuntu-latest
@@ -60,9 +60,9 @@ jobs:
             - name: Install dependencies
               run: |
                   yarn install --frozen-lockfile
-            - name: Run ESLint
+            - name: Run Prettier
               run: |
-                  yarn run bootstrap && yarn run test:prettier
+                  yarn run test:prettier
     typescript:
         name: TypeScript
         runs-on: ubuntu-latest
@@ -75,6 +75,6 @@ jobs:
             - name: Install dependencies
               run: |
                   yarn install --frozen-lockfile
-            - name: Run ESLint
+            - name: Run TypeScript
               run: |
-                  yarn run bootstrap && yarn run test:typecheck
+                  yarn run test:typecheck

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
                   yarn install --frozen-lockfile
             - name: Run ESLint
               run: |
-                  yarn run test:lint:js
+                  yarn run bootstrap && yarn run test:lint:js
     stylelint:
         name: Stylelint
         runs-on: ubuntu-latest


### PR DESCRIPTION
A few tests had incorrect names. Also, some had the `yarn run bootstrap` command where it wasn't needed.