### PR TITLE
Fix open graph page titles

### DIFF
--- a/www/src/components/page-header/index.jsx
+++ b/www/src/components/page-header/index.jsx
@@ -9,7 +9,9 @@ const PageHeader = ({ metaTitle, description, pageTitle }) => (
     <div className="mb5">
         <Helmet>
             {metaTitle && <title>{metaTitle} / Thumbprint</title>}
-            <meta name="twitter:title" content={`${metaTitle} / Thumbprint`} />
+            {metaTitle && <meta property="og:title" content={`${metaTitle} / Thumbprint`} />}
+            {metaTitle && <meta name="twitter:title" content={`${metaTitle} / Thumbprint`} />}
+
             {description && <meta name="twitter:description" content={description} />}
             {description && <meta name="description" content={description} />}
             {description && <meta property="og:description" content={description} />}


### PR DESCRIPTION
Currently all pages titles show up only as "Thumbprint" on Slack (and other things that use open graph).