### PR TITLE
Add 301! to redirects for Netlify changes

### DIFF
--- a/www/static/_redirects
+++ b/www/static/_redirects
@@ -7,238 +7,238 @@ https://thumbprint.thumbtack.com/* https://thumbprint.design/:splat 301!
 #
 
 ## Move from `/ui/<package_name>` to `/api/components/<package_name>/`.
-/ui/tp-ui-component-avatar /api/components/tp-ui-component-avatar
-/ui/tp-ui-component-form-note /api/components/tp-ui-component-form-note
-/ui/tp-ui-component-alert /api/components/tp-ui-component-alert
-/ui/tp-ui-component-loader /api/components/tp-ui-component-loader
-/ui/tp-ui-core-font-face /api/components/tp-ui-core-font-face
-/ui/tp-ui-core-function /api/components/tp-ui-core-function
-/ui/tp-ui-core-mixin /api/components/tp-ui-core-mixin
-/ui/tp-ui-core-reset /api/components/tp-ui-core-reset
-/ui/tp-ui-element-body /api/components/tp-ui-element-body
-/ui/tp-ui-element-checkbox /api/components/tp-ui-element-checkbox
-/ui/tp-ui-element-fieldset /api/components/tp-ui-element-fieldset
-/ui/tp-ui-element-button /api/components/tp-ui-element-button
-/ui/tp-ui-element-img /api/components/tp-ui-element-img
-/ui/tp-ui-element-hr /api/components/tp-ui-element-hr
-/ui/tp-ui-element-input /api/components/tp-ui-element-input
-/ui/tp-ui-element-link /api/components/tp-ui-element-link
-/ui/tp-ui-element-radio /api/components/tp-ui-element-radio
-/ui/tp-ui-element-label /api/components/tp-ui-element-label
-/ui/tp-ui-element-list /api/components/tp-ui-element-list
-/ui/tp-ui-element-select /api/components/tp-ui-element-select
-/ui/tp-ui-element-textarea /api/components/tp-ui-element-textarea
-/ui/tp-ui-element-table /api/components/tp-ui-element-table
-/ui/tp-ui-layout-block-list /api/components/tp-ui-layout-block-list
-/ui/tp-ui-element-type /api/components/tp-ui-element-type
-/ui/tp-ui-layout-button-row /api/components/tp-ui-layout-button-row
-/ui/tp-ui-layout-form /api/components/tp-ui-layout-form
-/ui/tp-ui-layout-grid /api/components/tp-ui-layout-grid
-/ui/tp-ui-layout-longread /api/components/tp-ui-layout-longread
-/ui/tp-ui-layout-wrap /api/components/tp-ui-layout-wrap
-/ui/tp-ui-layout-input-row /api/components/tp-ui-layout-input-row
-/ui/tp-ui-react-button /api/components/tp-ui-react-button
-/ui/tp-ui-react-button-row /api/components/tp-ui-react-button-row
-/ui/tp-ui-react-avatar /api/components/tp-ui-react-avatar
-/ui/tp-ui-react-form-note /api/components/tp-ui-react-form-note
-/ui/tp-ui-react-date-picker /api/components/tp-ui-react-date-picker
-/ui/tp-ui-react-checkbox /api/components/tp-ui-react-checkbox
-/ui/tp-ui-react-input /api/components/tp-ui-react-input
-/ui/tp-ui-react-grid /api/components/tp-ui-react-grid
-/ui/tp-ui-react-input-row /api/components/tp-ui-react-input-row
-/ui/tp-ui-react-label /api/components/tp-ui-react-label
-/ui/tp-ui-react-link /api/components/tp-ui-react-link
-/ui/tp-ui-react-modal-base /api/components/tp-ui-react-modal-base
-/ui/tp-ui-react-loader-dots /api/components/tp-ui-react-loader-dots
-/ui/tp-ui-react-modal-default /api/components/tp-ui-react-modal-default
-/ui/tp-ui-react-modal-standard /api/components/tp-ui-react-modal-standard
-/ui/tp-ui-react-modal-curtain /api/components/tp-ui-react-modal-curtain
-/ui/tp-ui-react-progress-bar /api/components/tp-ui-react-progress-bar
-/ui/tp-ui-react-radio /api/components/tp-ui-react-radio
-/ui/tp-ui-react-progress-bar-base /api/components/tp-ui-react-progress-bar-base
-/ui/tp-ui-react-select /api/components/tp-ui-react-select
-/ui/tp-ui-react-service-card /api/components/tp-ui-react-service-card
-/ui/tp-ui-react-tooltip /api/components/tp-ui-react-tooltip
-/ui/tp-ui-react-type /api/components/tp-ui-react-type
-/ui/tp-ui-react-textarea /api/components/tp-ui-react-textarea
-/ui/tp-ui-react-star-rating /api/components/tp-ui-react-star-rating
-/ui/tp-ui-react-wrap /api/components/tp-ui-react-wrap
-/ui/tp-ui-react-ui-action /api/components/tp-ui-react-ui-action
+/ui/tp-ui-component-avatar /api/components/tp-ui-component-avatar 301!
+/ui/tp-ui-component-form-note /api/components/tp-ui-component-form-note 301!
+/ui/tp-ui-component-alert /api/components/tp-ui-component-alert 301!
+/ui/tp-ui-component-loader /api/components/tp-ui-component-loader 301!
+/ui/tp-ui-core-font-face /api/components/tp-ui-core-font-face 301!
+/ui/tp-ui-core-function /api/components/tp-ui-core-function 301!
+/ui/tp-ui-core-mixin /api/components/tp-ui-core-mixin 301!
+/ui/tp-ui-core-reset /api/components/tp-ui-core-reset 301!
+/ui/tp-ui-element-body /api/components/tp-ui-element-body 301!
+/ui/tp-ui-element-checkbox /api/components/tp-ui-element-checkbox 301!
+/ui/tp-ui-element-fieldset /api/components/tp-ui-element-fieldset 301!
+/ui/tp-ui-element-button /api/components/tp-ui-element-button 301!
+/ui/tp-ui-element-img /api/components/tp-ui-element-img 301!
+/ui/tp-ui-element-hr /api/components/tp-ui-element-hr 301!
+/ui/tp-ui-element-input /api/components/tp-ui-element-input 301!
+/ui/tp-ui-element-link /api/components/tp-ui-element-link 301!
+/ui/tp-ui-element-radio /api/components/tp-ui-element-radio 301!
+/ui/tp-ui-element-label /api/components/tp-ui-element-label 301!
+/ui/tp-ui-element-list /api/components/tp-ui-element-list 301!
+/ui/tp-ui-element-select /api/components/tp-ui-element-select 301!
+/ui/tp-ui-element-textarea /api/components/tp-ui-element-textarea 301!
+/ui/tp-ui-element-table /api/components/tp-ui-element-table 301!
+/ui/tp-ui-layout-block-list /api/components/tp-ui-layout-block-list 301!
+/ui/tp-ui-element-type /api/components/tp-ui-element-type 301!
+/ui/tp-ui-layout-button-row /api/components/tp-ui-layout-button-row 301!
+/ui/tp-ui-layout-form /api/components/tp-ui-layout-form 301!
+/ui/tp-ui-layout-grid /api/components/tp-ui-layout-grid 301!
+/ui/tp-ui-layout-longread /api/components/tp-ui-layout-longread 301!
+/ui/tp-ui-layout-wrap /api/components/tp-ui-layout-wrap 301!
+/ui/tp-ui-layout-input-row /api/components/tp-ui-layout-input-row 301!
+/ui/tp-ui-react-button /api/components/tp-ui-react-button 301!
+/ui/tp-ui-react-button-row /api/components/tp-ui-react-button-row 301!
+/ui/tp-ui-react-avatar /api/components/tp-ui-react-avatar 301!
+/ui/tp-ui-react-form-note /api/components/tp-ui-react-form-note 301!
+/ui/tp-ui-react-date-picker /api/components/tp-ui-react-date-picker 301!
+/ui/tp-ui-react-checkbox /api/components/tp-ui-react-checkbox 301!
+/ui/tp-ui-react-input /api/components/tp-ui-react-input 301!
+/ui/tp-ui-react-grid /api/components/tp-ui-react-grid 301!
+/ui/tp-ui-react-input-row /api/components/tp-ui-react-input-row 301!
+/ui/tp-ui-react-label /api/components/tp-ui-react-label 301!
+/ui/tp-ui-react-link /api/components/tp-ui-react-link 301!
+/ui/tp-ui-react-modal-base /api/components/tp-ui-react-modal-base 301!
+/ui/tp-ui-react-loader-dots /api/components/tp-ui-react-loader-dots 301!
+/ui/tp-ui-react-modal-default /api/components/tp-ui-react-modal-default 301!
+/ui/tp-ui-react-modal-standard /api/components/tp-ui-react-modal-standard 301!
+/ui/tp-ui-react-modal-curtain /api/components/tp-ui-react-modal-curtain 301!
+/ui/tp-ui-react-progress-bar /api/components/tp-ui-react-progress-bar 301!
+/ui/tp-ui-react-radio /api/components/tp-ui-react-radio 301!
+/ui/tp-ui-react-progress-bar-base /api/components/tp-ui-react-progress-bar-base 301!
+/ui/tp-ui-react-select /api/components/tp-ui-react-select 301!
+/ui/tp-ui-react-service-card /api/components/tp-ui-react-service-card 301!
+/ui/tp-ui-react-tooltip /api/components/tp-ui-react-tooltip 301!
+/ui/tp-ui-react-type /api/components/tp-ui-react-type 301!
+/ui/tp-ui-react-textarea /api/components/tp-ui-react-textarea 301!
+/ui/tp-ui-react-star-rating /api/components/tp-ui-react-star-rating 301!
+/ui/tp-ui-react-wrap /api/components/tp-ui-react-wrap 301!
+/ui/tp-ui-react-ui-action /api/components/tp-ui-react-ui-action 301!
 
 ## Move from `/api/components/<package_name>` to
 ## `/api/components/<kit_category>/<kit_name>/<package_platform>`.
-/api/components/tp-ui-component-avatar /api/components/component/avatar/scss
-/api/components/tp-ui-component-form-note /api/components/component/form-note/scss
-/api/components/tp-ui-component-alert /api/components/component/alert/scss
-/api/components/tp-ui-component-loader /api/components/component/loader-dots/scss
-/api/components/tp-ui-core-font-face /api/components/core/font-face/scss
-/api/components/tp-ui-core-function /api/components/core/functions/scss
-/api/components/tp-ui-core-mixin /api/components/core/mixins/scss
-/api/components/tp-ui-core-reset /api/components/core/reset/scss
-/api/components/tp-ui-element-body /api/components/element/body/scss
-/api/components/tp-ui-element-checkbox /api/components/element/checkbox/scss
-/api/components/tp-ui-element-fieldset /api/components/element/fieldset/scss
-/api/components/tp-ui-element-button /api/components/element/button/scss
-/api/components/tp-ui-element-img /api/components/element/image/scss
-/api/components/tp-ui-element-hr /api/components/element/horizontal-rule/scss
-/api/components/tp-ui-element-input /api/components/element/input/scss
-/api/components/tp-ui-element-link /api/components/element/link/scss
-/api/components/tp-ui-element-radio /api/components/element/radio/scss
-/api/components/tp-ui-element-label /api/components/element/label/scss
-/api/components/tp-ui-element-list /api/components/element/list/scss
-/api/components/tp-ui-element-select /api/components/element/select/scss
-/api/components/tp-ui-element-textarea /api/components/element/textarea/scss
-/api/components/tp-ui-element-table /api/components/element/table/scss
-/api/components/tp-ui-layout-block-list /api/components/element/textarea/scss
-/api/components/tp-ui-element-type /api/components/element/type/scss
-/api/components/tp-ui-layout-button-row /api/components/layout/button-row/scss
-/api/components/tp-ui-layout-form /api/components/layout/form/scss
-/api/components/tp-ui-layout-grid /api/components/layout/grid/scss
-/api/components/tp-ui-layout-longread /api/components/layout/longread/scss
-/api/components/tp-ui-layout-wrap /api/components/layout/wrap/scss
-/api/components/tp-ui-layout-input-row /api/components/layout/input-row/scss
-/api/components/tp-ui-react-button /api/components/element/button/react
-/api/components/tp-ui-react-button-row /api/components/layout/button-row/react
-/api/components/tp-ui-react-avatar /api/components/component/avatar/react
-/api/components/tp-ui-react-form-note /api/components/component/form-note/react
-/api/components/tp-ui-react-date-picker /api/components/component/date-picker/react
-/api/components/tp-ui-react-checkbox /api/components/element/checkbox/react
-/api/components/tp-ui-react-input /api/components/element/input/react
-/api/components/tp-ui-react-grid /api/components/layout/grid/react
-/api/components/tp-ui-react-input-row /api/components/layout/input-row/react
-/api/components/tp-ui-react-label /api/components/element/label/react
-/api/components/tp-ui-react-link /api/components/element/link/react
-/api/components/tp-ui-react-modal-base /api/components/component/modal-base/react
-/api/components/tp-ui-react-loader-dots /api/components/component/loader-dots/react
-/api/components/tp-ui-react-modal-default /api/components/component/modal-default/react
-/api/components/tp-ui-react-modal-standard /api/components/component/modal-standard/react
-/api/components/tp-ui-react-modal-curtain /api/components/component/modal-curtain/react
-/api/components/tp-ui-react-progress-bar /api/components/component/progress-bar/react
-/api/components/tp-ui-react-radio /api/components/element/radio/react
-/api/components/tp-ui-react-progress-bar-base /api/components/component/progress-bar-base/react
-/api/components/tp-ui-react-select /api/components/element/select/react
-/api/components/tp-ui-react-service-card /api/components/component/service-card/react
-/api/components/tp-ui-react-tooltip /api/components/component/tooltip/react
-/api/components/tp-ui-react-type /api/components/element/type/react/
-/api/components/tp-ui-react-textarea /api/components/element/textarea/react
-/api/components/tp-ui-react-star-rating /api/components/component/star-rating/react
-/api/components/tp-ui-react-wrap /api/components/layout/wrap/react
-/api/components/tp-ui-react-ui-action /api/components/component/ui-action/react
+/api/components/tp-ui-component-avatar /api/components/component/avatar/scss 301!
+/api/components/tp-ui-component-form-note /api/components/component/form-note/scss 301!
+/api/components/tp-ui-component-alert /api/components/component/alert/scss 301!
+/api/components/tp-ui-component-loader /api/components/component/loader-dots/scss 301!
+/api/components/tp-ui-core-font-face /api/components/core/font-face/scss 301!
+/api/components/tp-ui-core-function /api/components/core/functions/scss 301!
+/api/components/tp-ui-core-mixin /api/components/core/mixins/scss 301!
+/api/components/tp-ui-core-reset /api/components/core/reset/scss 301!
+/api/components/tp-ui-element-body /api/components/element/body/scss 301!
+/api/components/tp-ui-element-checkbox /api/components/element/checkbox/scss 301!
+/api/components/tp-ui-element-fieldset /api/components/element/fieldset/scss 301!
+/api/components/tp-ui-element-button /api/components/element/button/scss 301!
+/api/components/tp-ui-element-img /api/components/element/image/scss 301!
+/api/components/tp-ui-element-hr /api/components/element/horizontal-rule/scss 301!
+/api/components/tp-ui-element-input /api/components/element/input/scss 301!
+/api/components/tp-ui-element-link /api/components/element/link/scss 301!
+/api/components/tp-ui-element-radio /api/components/element/radio/scss 301!
+/api/components/tp-ui-element-label /api/components/element/label/scss 301!
+/api/components/tp-ui-element-list /api/components/element/list/scss 301!
+/api/components/tp-ui-element-select /api/components/element/select/scss 301!
+/api/components/tp-ui-element-textarea /api/components/element/textarea/scss 301!
+/api/components/tp-ui-element-table /api/components/element/table/scss 301!
+/api/components/tp-ui-layout-block-list /api/components/element/textarea/scss 301!
+/api/components/tp-ui-element-type /api/components/element/type/scss 301!
+/api/components/tp-ui-layout-button-row /api/components/layout/button-row/scss 301!
+/api/components/tp-ui-layout-form /api/components/layout/form/scss 301!
+/api/components/tp-ui-layout-grid /api/components/layout/grid/scss 301!
+/api/components/tp-ui-layout-longread /api/components/layout/longread/scss 301!
+/api/components/tp-ui-layout-wrap /api/components/layout/wrap/scss 301!
+/api/components/tp-ui-layout-input-row /api/components/layout/input-row/scss 301!
+/api/components/tp-ui-react-button /api/components/element/button/react 301!
+/api/components/tp-ui-react-button-row /api/components/layout/button-row/react 301!
+/api/components/tp-ui-react-avatar /api/components/component/avatar/react 301!
+/api/components/tp-ui-react-form-note /api/components/component/form-note/react 301!
+/api/components/tp-ui-react-date-picker /api/components/component/date-picker/react 301!
+/api/components/tp-ui-react-checkbox /api/components/element/checkbox/react 301!
+/api/components/tp-ui-react-input /api/components/element/input/react 301!
+/api/components/tp-ui-react-grid /api/components/layout/grid/react 301!
+/api/components/tp-ui-react-input-row /api/components/layout/input-row/react 301!
+/api/components/tp-ui-react-label /api/components/element/label/react 301!
+/api/components/tp-ui-react-link /api/components/element/link/react 301!
+/api/components/tp-ui-react-modal-base /api/components/component/modal-base/react 301!
+/api/components/tp-ui-react-loader-dots /api/components/component/loader-dots/react 301!
+/api/components/tp-ui-react-modal-default /api/components/component/modal-default/react 301!
+/api/components/tp-ui-react-modal-standard /api/components/component/modal-standard/react 301!
+/api/components/tp-ui-react-modal-curtain /api/components/component/modal-curtain/react 301!
+/api/components/tp-ui-react-progress-bar /api/components/component/progress-bar/react 301!
+/api/components/tp-ui-react-radio /api/components/element/radio/react 301!
+/api/components/tp-ui-react-progress-bar-base /api/components/component/progress-bar-base/react 301!
+/api/components/tp-ui-react-select /api/components/element/select/react 301!
+/api/components/tp-ui-react-service-card /api/components/component/service-card/react 301!
+/api/components/tp-ui-react-tooltip /api/components/component/tooltip/react 301!
+/api/components/tp-ui-react-type /api/components/element/type/react/ 301!
+/api/components/tp-ui-react-textarea /api/components/element/textarea/react 301!
+/api/components/tp-ui-react-star-rating /api/components/component/star-rating/react 301!
+/api/components/tp-ui-react-wrap /api/components/layout/wrap/react 301!
+/api/components/tp-ui-react-ui-action /api/components/component/ui-action/react 301!
 
 ## Launch thumbprint.design in Jan. 2019
-/api/components/component/alert/scss /components/alert/scss
-/api/components/component/alert/scss /components/alert/scss
-/api/components/component/form-note/scss /components/form-note/scss
-/api/components/component/loader-dots/scss /components/loader-dots/scss
-/api/components/core/font-face/scss /components/font-face/scss
-/api/components/core/functions/scss /components/functions/scss
-/api/components/core/mixins/scss /components/mixins/scss
-/api/components/component/avatar/scss /components/avatar/scss
-/api/components/element/button/scss /components/button/scss
-/api/components/core/reset/scss /components/reset/scss
-/api/components/element/checkbox/scss /components/checkbox/scss
-/api/components/element/body/scss /components/body/scss
-/api/components/element/fieldset/scss /components/fieldset/scss
-/api/components/element/horizontal-rule/scss /components/horizontal-rule/scss
-/api/components/element/image/scss /components/image/scss
-/api/components/element/label/scss /components/label/scss
-/api/components/element/input/scss /components/input/scss
-/api/components/element/link/scss /components/link/scss
-/api/components/element/list/scss /components/list/scss
-/api/components/element/radio/scss /components/radio/scss
-/api/components/element/select/scss /components/select/scss
-/api/components/element/table/scss /components/table/scss
-/api/components/element/textarea/scss /components/textarea/scss
-/api/components/layout/block-list/scss /components/block-list/scss
-/api/components/layout/button-row/scss /components/button-row/scss
-/api/components/element/type/scss /components/type/scss
-/api/components/layout/form/scss /components/form/scss
-/api/components/layout/input-row/scss /components/input-row/scss
-/api/components/layout/grid/scss /components/grid/scss
-/api/components/layout/longread/scss /components/longread/scss
-/api/components/layout/wrap/scss /components/wrap/scss
-/api/components/element/button/react /components/button/react
-/api/components/component/avatar/react /components/avatar/react
-/api/components/layout/button-row/react /components/button-row/react
-/api/components/component/form-note/react /components/form-note/react
-/api/components/element/checkbox/react /components/checkbox/react
-/api/components/component/carousel/react /components/carousel/react
-/api/components/component/date-picker/react /components/date-picker/react
-/api/components/layout/grid/react /components/grid/react
-/api/components/element/link/react /components/link/react
-/api/components/element/input/react /components/input/react
-/api/components/layout/input-row/react /components/input-row/react
-/api/components/element/label/react /components/label/react
-/api/components/element/list/react /components/list/react
-/api/components/component/modal-base/react /components/modal-base/react
-/api/components/component/modal-curtain/react /components/modal-curtain/react
-/api/components/component/loader-dots/react /components/loader-dots/react
-/api/components/component/modal-default/react /components/modal-default/react
-/api/components/component/modal-standard/react /components/modal-standard/react
-/api/components/component/progress-bar/react /components/progress-bar/react
-/api/components/component/progress-bar-base/react /components/progress-bar-base/react
-/api/components/element/radio/react /components/radio/react
-/api/components/element/select/react /components/select/react
-/api/components/component/service-card/react /components/service-card/react
-/api/components/component/star-rating/react /components/star-rating/react
-/api/components/element/type/react /components/type/react
-/api/components/element/textarea/react /components/textarea/react
-/api/components/component/tooltip/react /components/tooltip/react
-/api/components/component/ui-action/react /components/ui-action/react
-/api/components/layout/wrap/react /components/wrap/react
-/notes/2018-12-18 /updates/notes/2018-12-18
-/notes/2018-12-18/email /updates/notes/2018-12-18
-/notes/2018-11-06 /updates/notes/2018-11-06/
-/notes/2018-11-06/email /updates/notes/2018-11-06
-/notes/2018-10-23 /updates/notes/2018-10-23/
-/notes/2018-10-23/email /updates/notes/2018-10-23
-/notes/2018-10-09 /updates/notes/2018-10-09/
-/notes/2018-10-09/email /updates/notes/2018-10-09
-/notes/2018-09-25 /updates/notes/2018-09-25/
-/notes/2018-09-25/email /updates/notes/2018-09-25
-/notes/2018-09-11 /updates/notes/2018-09-11/
-/notes/2018-09-11/email /updates/notes/2018-09-11
-/notes/2018-08-28 /updates/notes/2018-08-28/
-/notes/2018-08-28/email /updates/notes/2018-08-28
-/notes/2018-08-16 /updates/notes/2018-08-16/
-/notes/2018-08-16/email /updates/notes/2018-08-16
-/guide/product/foundations/aspect-ratio /guide/product/aspect-ratio
-/guide/product/foundations/design-tokens /guide/product/design-tokens
-/guide/product/layout/grid /components/grid/usage/
-/guide/product/foundations/color /guide/product/color
-/guide/product/foundations/iconography /guide/product/iconography
-/guide/product/patterns/modals /guide/product/modals
-/guide/product/components/button /components/button/usage/
-/guide/product/components/service-cards /guide/product/service-cards
-/guide/product/layout/spacers /guide/product/spacers
-/guide/product/foundations/toolkits /guide/product/toolkits
-/guide/product/layout/wrap /components/wrap/usage/
-/guide/product/components/tooltips /components/tooltips/usage
-/guide/product/foundations/typography /guide/product/typography
-/api/atomic/about /atomic/usage
-/api/atomic /atomic
-/api/tokens /tokens
+/api/components/component/alert/scss /components/alert/scss 301!
+/api/components/component/alert/scss /components/alert/scss 301!
+/api/components/component/form-note/scss /components/form-note/scss 301!
+/api/components/component/loader-dots/scss /components/loader-dots/scss 301!
+/api/components/core/font-face/scss /components/font-face/scss 301!
+/api/components/core/functions/scss /components/functions/scss 301!
+/api/components/core/mixins/scss /components/mixins/scss 301!
+/api/components/component/avatar/scss /components/avatar/scss 301!
+/api/components/element/button/scss /components/button/scss 301!
+/api/components/core/reset/scss /components/reset/scss 301!
+/api/components/element/checkbox/scss /components/checkbox/scss 301!
+/api/components/element/body/scss /components/body/scss 301!
+/api/components/element/fieldset/scss /components/fieldset/scss 301!
+/api/components/element/horizontal-rule/scss /components/horizontal-rule/scss 301!
+/api/components/element/image/scss /components/image/scss 301!
+/api/components/element/label/scss /components/label/scss 301!
+/api/components/element/input/scss /components/input/scss 301!
+/api/components/element/link/scss /components/link/scss 301!
+/api/components/element/list/scss /components/list/scss 301!
+/api/components/element/radio/scss /components/radio/scss 301!
+/api/components/element/select/scss /components/select/scss 301!
+/api/components/element/table/scss /components/table/scss 301!
+/api/components/element/textarea/scss /components/textarea/scss 301!
+/api/components/layout/block-list/scss /components/block-list/scss 301!
+/api/components/layout/button-row/scss /components/button-row/scss 301!
+/api/components/element/type/scss /components/type/scss 301!
+/api/components/layout/form/scss /components/form/scss 301!
+/api/components/layout/input-row/scss /components/input-row/scss 301!
+/api/components/layout/grid/scss /components/grid/scss 301!
+/api/components/layout/longread/scss /components/longread/scss 301!
+/api/components/layout/wrap/scss /components/wrap/scss 301!
+/api/components/element/button/react /components/button/react 301!
+/api/components/component/avatar/react /components/avatar/react 301!
+/api/components/layout/button-row/react /components/button-row/react 301!
+/api/components/component/form-note/react /components/form-note/react 301!
+/api/components/element/checkbox/react /components/checkbox/react 301!
+/api/components/component/carousel/react /components/carousel/react 301!
+/api/components/component/date-picker/react /components/date-picker/react 301!
+/api/components/layout/grid/react /components/grid/react 301!
+/api/components/element/link/react /components/link/react 301!
+/api/components/element/input/react /components/input/react 301!
+/api/components/layout/input-row/react /components/input-row/react 301!
+/api/components/element/label/react /components/label/react 301!
+/api/components/element/list/react /components/list/react 301!
+/api/components/component/modal-base/react /components/modal-base/react 301!
+/api/components/component/modal-curtain/react /components/modal-curtain/react 301!
+/api/components/component/loader-dots/react /components/loader-dots/react 301!
+/api/components/component/modal-default/react /components/modal-default/react 301!
+/api/components/component/modal-standard/react /components/modal-standard/react 301!
+/api/components/component/progress-bar/react /components/progress-bar/react 301!
+/api/components/component/progress-bar-base/react /components/progress-bar-base/react 301!
+/api/components/element/radio/react /components/radio/react 301!
+/api/components/element/select/react /components/select/react 301!
+/api/components/component/service-card/react /components/service-card/react 301!
+/api/components/component/star-rating/react /components/star-rating/react 301!
+/api/components/element/type/react /components/type/react 301!
+/api/components/element/textarea/react /components/textarea/react 301!
+/api/components/component/tooltip/react /components/tooltip/react 301!
+/api/components/component/ui-action/react /components/ui-action/react 301!
+/api/components/layout/wrap/react /components/wrap/react 301!
+/notes/2018-12-18 /updates/notes/2018-12-18 301!
+/notes/2018-12-18/email /updates/notes/2018-12-18 301!
+/notes/2018-11-06 /updates/notes/2018-11-06/ 301!
+/notes/2018-11-06/email /updates/notes/2018-11-06 301!
+/notes/2018-10-23 /updates/notes/2018-10-23/ 301!
+/notes/2018-10-23/email /updates/notes/2018-10-23 301!
+/notes/2018-10-09 /updates/notes/2018-10-09/ 301!
+/notes/2018-10-09/email /updates/notes/2018-10-09 301!
+/notes/2018-09-25 /updates/notes/2018-09-25/ 301!
+/notes/2018-09-25/email /updates/notes/2018-09-25 301!
+/notes/2018-09-11 /updates/notes/2018-09-11/ 301!
+/notes/2018-09-11/email /updates/notes/2018-09-11 301!
+/notes/2018-08-28 /updates/notes/2018-08-28/ 301!
+/notes/2018-08-28/email /updates/notes/2018-08-28 301!
+/notes/2018-08-16 /updates/notes/2018-08-16/ 301!
+/notes/2018-08-16/email /updates/notes/2018-08-16 301!
+/guide/product/foundations/aspect-ratio /guide/product/aspect-ratio 301!
+/guide/product/foundations/design-tokens /guide/product/design-tokens 301!
+/guide/product/layout/grid /components/grid/usage/ 301!
+/guide/product/foundations/color /guide/product/color 301!
+/guide/product/foundations/iconography /guide/product/iconography 301!
+/guide/product/patterns/modals /guide/product/modals 301!
+/guide/product/components/button /components/button/usage/ 301!
+/guide/product/components/service-cards /guide/product/service-cards 301!
+/guide/product/layout/spacers /guide/product/spacers 301!
+/guide/product/foundations/toolkits /guide/product/toolkits 301!
+/guide/product/layout/wrap /components/wrap/usage/ 301!
+/guide/product/components/tooltips /components/tooltips/usage 301!
+/guide/product/foundations/typography /guide/product/typography 301!
+/api/atomic/about /atomic/usage 301!
+/api/atomic /atomic 301!
+/api/tokens /tokens 301!
 
 # Combine mixins and functions documentation
-/components/functions/scss /components/mixins/scss
+/components/functions/scss /components/mixins/scss 301!
 
 # Use tabs and actual pages for token languages instead of a select dropdown
-/tokens /tokens/scss
+/tokens /tokens/scss 301!
 
 # Rename a few components as part of "The Great Alignment" effort
 # https://github.com/thumbtack/thumbprint/issues/566
-/components/date-picker/react/ /components/calendar/react/
-/components/select/react/ /components/dropdown/react/
-/components/select/scss/ /components/dropdown/scss/
-/components/modal-default/usage/ /components/modal/usage/
-/components/modal-default/react/ /components/modal/react/
-/components/textarea/react/ /components/text-area/react/
-/components/textarea/scss/ /components/text-area/scss/
-/components/input/react/ /components/text-input/react/
-/components/input/scss/ /components/text-input/scss/
+/components/date-picker/react/ /components/calendar/react/  301!
+/components/select/react/ /components/dropdown/react/  301!
+/components/select/scss/ /components/dropdown/scss/  301!
+/components/modal-default/usage/ /components/modal/usage/  301!
+/components/modal-default/react/ /components/modal/react/  301!
+/components/textarea/react/ /components/text-area/react/  301!
+/components/textarea/scss/ /components/text-area/scss/  301!
+/components/input/react/ /components/text-input/react/  301!
+/components/input/scss/ /components/text-input/scss/  301!
 
 # The `<body>` and CSS reset styles used to be part of the Thumbprint SCSS
 # package. They are now part of the `thumbprint-global-css` package and
 # documented on a different page.
-/components/body/scss/ /components/global-css/scss/
-/components/reset/scss/ /components/global-css/scss/
+/components/body/scss/ /components/global-css/scss/  301!
+/components/reset/scss/ /components/global-css/scss/  301!


### PR DESCRIPTION
From Netlify:

For more information on the nature of the bug and how it affects redirect rules, please visit the Community topic on [our fix for forced redirects and shadowing behavior](https://community.netlify.com/t/changed-behavior-in-redirects/10084).

The redirect rules listed below are currently behaving as forced redirects (redirecting past existing content), even though you haven’t explicitly configured them to do so. You may want to check each redirect to be sure you want to continue this behavior, and if so, explicitly mark the rule as forced. In a _redirects file, you can do this by adding ! to the [redirect status code](https://docs.netlify.com/routing/redirects/redirect-options/#http-status-codes).

---
Fixes #671 