### PR TITLE
Add more files to TypeScript excludes

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,5 +22,11 @@
         "esModuleInterop": true
     },
     "include": ["packages/**/*", "typings/**/*", "www/**/*"],
-    "exclude": ["**/node_modules/**/*", "**/dist/**/*"]
+    "exclude": [
+        "**/node_modules/**/*",
+        "**/dist/**/*",
+        "www/.cache/**",
+        "www/public/**",
+        "packages/*/.cache/**"
+    ]
 }


### PR DESCRIPTION
VSCode said that there are too many files in the project and asked to add more files to the exclude. This makes the error go away.