### PR TITLE
Cache `yarn install` in GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,17 +12,13 @@ jobs:
               uses: actions/setup-node@v1
               with:
                   node-version: 12.x
-            - name: Get the Yarn cache directory path
-              id: yarn-cache-dir-path
-              run: echo "::set-output name=dir::$(yarn cache dir)"
             - name: Restore Yarn cache
               uses: actions/cache@v2
-              id: yarn-cache
               with:
-                  path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-                  restore-keys: |
-                      ${{ runner.os }}-yarn-
+                  path: |
+                      node_modules
+                      */*/node_modules
+                  key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
             - name: Install dependencies
               run: |
                   yarn install --frozen-lockfile
@@ -38,17 +34,13 @@ jobs:
               uses: actions/setup-node@v1
               with:
                   node-version: 12.x
-            - name: Get the Yarn cache directory path
-              id: yarn-cache-dir-path
-              run: echo "::set-output name=dir::$(yarn cache dir)"
             - name: Restore Yarn cache
               uses: actions/cache@v2
-              id: yarn-cache
               with:
-                  path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-                  restore-keys: |
-                      ${{ runner.os }}-yarn-
+                  path: |
+                      node_modules
+                      */*/node_modules
+                  key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
             - name: Install dependencies
               run: |
                   yarn install --frozen-lockfile
@@ -64,17 +56,13 @@ jobs:
               uses: actions/setup-node@v1
               with:
                   node-version: 12.x
-            - name: Get the Yarn cache directory path
-              id: yarn-cache-dir-path
-              run: echo "::set-output name=dir::$(yarn cache dir)"
             - name: Restore Yarn cache
               uses: actions/cache@v2
-              id: yarn-cache
               with:
-                  path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-                  restore-keys: |
-                      ${{ runner.os }}-yarn-
+                  path: |
+                      node_modules
+                      */*/node_modules
+                  key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
             - name: Install dependencies
               run: |
                   yarn install --frozen-lockfile
@@ -90,17 +78,13 @@ jobs:
               uses: actions/setup-node@v1
               with:
                   node-version: 12.x
-            - name: Get the Yarn cache directory path
-              id: yarn-cache-dir-path
-              run: echo "::set-output name=dir::$(yarn cache dir)"
             - name: Restore Yarn cache
               uses: actions/cache@v2
-              id: yarn-cache
               with:
-                  path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-                  restore-keys: |
-                      ${{ runner.os }}-yarn-
+                  path: |
+                      node_modules
+                      */*/node_modules
+                  key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
             - name: Install dependencies
               run: |
                   yarn install --frozen-lockfile
@@ -116,17 +100,13 @@ jobs:
               uses: actions/setup-node@v1
               with:
                   node-version: 12.x
-            - name: Get the Yarn cache directory path
-              id: yarn-cache-dir-path
-              run: echo "::set-output name=dir::$(yarn cache dir)"
             - name: Restore Yarn cache
               uses: actions/cache@v2
-              id: yarn-cache
               with:
-                  path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-                  restore-keys: |
-                      ${{ runner.os }}-yarn-
+                  path: |
+                      node_modules
+                      */*/node_modules
+                  key: ${{ runner.os }}-${{ hashFiles('**/yarn.lock') }}
             - name: Install dependencies
               run: |
                   yarn install --frozen-lockfile

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,19 @@ jobs:
               uses: actions/setup-node@v1
               with:
                   node-version: 12.x
+            - name: Get the Yarn cache directory path
+              id: yarn-cache-dir-path
+              run: echo "::set-output name=dir::$(yarn cache dir)"
+            - name: Restore Yarn cache
+              uses: actions/cache@v2
+              id: yarn-cache
+              with:
+                  path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+                  restore-keys: |
+                      ${{ runner.os }}-yarn-
             - name: Install dependencies
+              if: steps.yarn-cache.outputs.cache-hit != 'true'
               run: |
                   yarn install --frozen-lockfile
             - name: Run Jest
@@ -27,7 +39,19 @@ jobs:
               uses: actions/setup-node@v1
               with:
                   node-version: 12.x
+            - name: Get the Yarn cache directory path
+              id: yarn-cache-dir-path
+              run: echo "::set-output name=dir::$(yarn cache dir)"
+            - name: Restore Yarn cache
+              uses: actions/cache@v2
+              id: yarn-cache
+              with:
+                  path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+                  restore-keys: |
+                      ${{ runner.os }}-yarn-
             - name: Install dependencies
+              if: steps.yarn-cache.outputs.cache-hit != 'true'
               run: |
                   yarn install --frozen-lockfile
             - name: Run ESLint
@@ -42,7 +66,19 @@ jobs:
               uses: actions/setup-node@v1
               with:
                   node-version: 12.x
+            - name: Get the Yarn cache directory path
+              id: yarn-cache-dir-path
+              run: echo "::set-output name=dir::$(yarn cache dir)"
+            - name: Restore Yarn cache
+              uses: actions/cache@v2
+              id: yarn-cache
+              with:
+                  path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+                  restore-keys: |
+                      ${{ runner.os }}-yarn-
             - name: Install dependencies
+              if: steps.yarn-cache.outputs.cache-hit != 'true'
               run: |
                   yarn install --frozen-lockfile
             - name: Run Stylelint
@@ -57,7 +93,19 @@ jobs:
               uses: actions/setup-node@v1
               with:
                   node-version: 12.x
+            - name: Get the Yarn cache directory path
+              id: yarn-cache-dir-path
+              run: echo "::set-output name=dir::$(yarn cache dir)"
+            - name: Restore Yarn cache
+              uses: actions/cache@v2
+              id: yarn-cache
+              with:
+                  path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+                  restore-keys: |
+                      ${{ runner.os }}-yarn-
             - name: Install dependencies
+              if: steps.yarn-cache.outputs.cache-hit != 'true'
               run: |
                   yarn install --frozen-lockfile
             - name: Run Prettier
@@ -72,7 +120,19 @@ jobs:
               uses: actions/setup-node@v1
               with:
                   node-version: 12.x
+            - name: Get the Yarn cache directory path
+              id: yarn-cache-dir-path
+              run: echo "::set-output name=dir::$(yarn cache dir)"
+            - name: Restore Yarn cache
+              uses: actions/cache@v2
+              id: yarn-cache
+              with:
+                  path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+                  restore-keys: |
+                      ${{ runner.os }}-yarn-
             - name: Install dependencies
+              if: steps.yarn-cache.outputs.cache-hit != 'true'
               run: |
                   yarn install --frozen-lockfile
             - name: Run TypeScript

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,6 @@ jobs:
                   restore-keys: |
                       ${{ runner.os }}-yarn-
             - name: Install dependencies
-              if: steps.yarn-cache.outputs.cache-hit != 'true'
               run: |
                   yarn install --frozen-lockfile
             - name: Run Jest
@@ -51,7 +50,6 @@ jobs:
                   restore-keys: |
                       ${{ runner.os }}-yarn-
             - name: Install dependencies
-              if: steps.yarn-cache.outputs.cache-hit != 'true'
               run: |
                   yarn install --frozen-lockfile
             - name: Run ESLint
@@ -78,7 +76,6 @@ jobs:
                   restore-keys: |
                       ${{ runner.os }}-yarn-
             - name: Install dependencies
-              if: steps.yarn-cache.outputs.cache-hit != 'true'
               run: |
                   yarn install --frozen-lockfile
             - name: Run Stylelint
@@ -105,7 +102,6 @@ jobs:
                   restore-keys: |
                       ${{ runner.os }}-yarn-
             - name: Install dependencies
-              if: steps.yarn-cache.outputs.cache-hit != 'true'
               run: |
                   yarn install --frozen-lockfile
             - name: Run Prettier
@@ -132,7 +128,6 @@ jobs:
                   restore-keys: |
                       ${{ runner.os }}-yarn-
             - name: Install dependencies
-              if: steps.yarn-cache.outputs.cache-hit != 'true'
               run: |
                   yarn install --frozen-lockfile
             - name: Run TypeScript

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Test build status](https://github.com/thumbtack/thumbprint/workflows/Test/badge.svg)](https://github.com/thumbtack/thumbprint/actions?query=workflow%3ATest)
 
-# Thumbprint!
+# Thumbprint
 
 Thumbprint is the design system at Thumbtack. Though its primary purpose to support Thumbtack projects, we have open-sourced it for those interested in how we build and manage our documentation and code.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Test build status](https://github.com/thumbtack/thumbprint/workflows/Test/badge.svg)](https://github.com/thumbtack/thumbprint/actions?query=workflow%3ATest)
 
-# Thumbprint
+# Thumbprint!
 
 Thumbprint is the design system at Thumbtack. Though its primary purpose to support Thumbtack projects, we have open-sourced it for those interested in how we build and manage our documentation and code.
 


### PR DESCRIPTION
This uses the example from:
https://github.com/actions/cache/blob/master/examples.md#node---lerna

We use that instead of the Yarn example since:

1. We use workspaces
2. The Yarn example, from what I understand, only caches the Yarn cache directory (output of `yarn cache dir`), not the `node_modules`.

This removes ~2min 20s from our test CI.