### PR TITLE
Remove unused IntersectionObserver mock

### DIFF
--- a/packages/thumbprint-react/CHANGELOG.md
+++ b/packages/thumbprint-react/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+-   [Patch] Remove unusued `IntersectionObserver` test mock.
+
 ## 12.5.1 - 2020-06-18
 
 ### Fixed

--- a/packages/thumbprint-react/__mocks__/intersection-observer.js
+++ b/packages/thumbprint-react/__mocks__/intersection-observer.js
@@ -1,1 +1,0 @@
-export default {};


### PR DESCRIPTION
Tests still pass without it. Likely isn't needed anymore because of the move away from `react-intersection-observer`.