### PR TITLE
Improve IntersectionObserver logic

### DIFF
--- a/packages/thumbprint-react/CHANGELOG.md
+++ b/packages/thumbprint-react/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 -   [Patch] Remove unusued `IntersectionObserver` test mock.
+-   [Patch] Fix IntersectionObserver logic.
 
 ## 12.5.1 - 2020-06-18
 

--- a/packages/thumbprint-react/components/Image/use-lazy-load.ts
+++ b/packages/thumbprint-react/components/Image/use-lazy-load.ts
@@ -57,9 +57,9 @@ export default function useLazyLoad(
                         // IntersectionObserver.
                         const entry = entries[0];
 
-                        // We use `intersectionRatio` rather than `isIntersecting` because Edge 15
+                        // We use both `isIntersecting` and `intersectionRatio` because Edge 15
                         // doesn't support `isIntersecting`.
-                        if (entry.intersectionRatio > 0) {
+                        if (entry.isIntersecting || entry.intersectionRatio > 0) {
                             // We need to pass in a function to `setNumHaveIntersected` so that it
                             // can get the current value of `numHaveIntersected` within this
                             // callback.


### PR DESCRIPTION
Relying only on `intersectionRatio` caused a bug where images within a modal image gallery were not being properly detected as visible. `intersectionRatio` was `0` but `isIntersecting` was `true`.

Here's some related issues on this topic:

* https://github.com/verlok/vanilla-lazyload/issues/293
* https://github.com/w3c/IntersectionObserver/issues/328
* https://github.com/thebuilder/react-intersection-observer/blob/7940bfe255f88e43eeb9a4db3fd1569c40e04eb1/src/intersection.ts#L138-L163

I tested this out in website on IE 15, latest Firefox, iOS 9, a more modern iOS, and Samsung Galaxy S9 Plus.