### PR TITLE
Upgrade Thumbprint Tokens

### DIFF
--- a/packages/thumbprint-atomic/CHANGELOG.md
+++ b/packages/thumbprint-atomic/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+-   [Patch] Upgrade Thumbprint Tokens to latest version. This pulls in small color tweaks to improve accessibility.
+
 ## 4.1.0 - 2020-04-10
 
 ### Added

--- a/packages/thumbprint-atomic/__snapshots__/test.js.snap
+++ b/packages/thumbprint-atomic/__snapshots__/test.js.snap
@@ -99,7 +99,7 @@ exports[`compiles correctly 1`] = `
   border-color: #5968e2 !important;
 }
 .b-purple {
-  border-color: #a97ff0 !important;
+  border-color: #8d56eb !important;
 }
 .b-green {
   border-color: #2db783 !important;
@@ -244,7 +244,7 @@ _:-ms-lang(x) {
   color: #5968e2 !important;
 }
 .purple {
-  color: #a97ff0 !important;
+  color: #8d56eb !important;
 }
 .green {
   color: #2db783 !important;
@@ -280,7 +280,7 @@ _:-ms-lang(x) {
   background-color: #5968e2 !important;
 }
 .bg-purple {
-  background-color: #a97ff0 !important;
+  background-color: #8d56eb !important;
 }
 .bg-green {
   background-color: #2db783 !important;
@@ -322,7 +322,7 @@ _:-ms-lang(x) {
 }
 .hover-purple:focus,
 .hover-purple:hover {
-  color: #a97ff0 !important;
+  color: #8d56eb !important;
 }
 .hover-green:focus,
 .hover-green:hover {
@@ -370,7 +370,7 @@ _:-ms-lang(x) {
 }
 .hover-bg-purple:focus,
 .hover-bg-purple:hover {
-  background-color: #a97ff0 !important;
+  background-color: #8d56eb !important;
 }
 .hover-bg-green:focus,
 .hover-bg-green:hover {

--- a/packages/thumbprint-atomic/package.json
+++ b/packages/thumbprint-atomic/package.json
@@ -21,7 +21,7 @@
     },
     "devDependencies": {
         "@thumbtack/thumbprint-scss": "^4.0.0",
-        "@thumbtack/thumbprint-tokens": "^8.3.3",
+        "@thumbtack/thumbprint-tokens": "^12.1.1",
         "autoprefixer": "^9.0.1",
         "css-mqpacker": "^7.0.0",
         "cssnano": "^4.1.0",

--- a/packages/thumbprint-font-face/CHANGELOG.md
+++ b/packages/thumbprint-font-face/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+-   [Patch] Upgrade Thumbprint Tokens to latest version. The changes do not affect this package.
+
 ## 1.0.14 - 2020-01-09
 
 ### Changed

--- a/packages/thumbprint-font-face/package.json
+++ b/packages/thumbprint-font-face/package.json
@@ -24,7 +24,7 @@
     },
     "homepage": "https://github.com/thumbtack/thumbprint/blob/master/packages/thumbprint-font-face/#readme",
     "dependencies": {
-        "@thumbtack/thumbprint-tokens": "^8.3.3"
+        "@thumbtack/thumbprint-tokens": "^12.1.1"
     },
     "devDependencies": {
         "node-sass-tilde-importer": "2.0.0-alpha.1",

--- a/packages/thumbprint-global-css/CHANGELOG.md
+++ b/packages/thumbprint-global-css/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+-   [Patch] Upgrade Thumbprint Tokens to latest version. The changes do not affect this package.
+
 ## 0.1.16 - 2019-10-17
 
 ### Changed

--- a/packages/thumbprint-global-css/package.json
+++ b/packages/thumbprint-global-css/package.json
@@ -20,7 +20,7 @@
         "prepublishOnly": "../../scripts/should-build-package.js -- yarn start"
     },
     "devDependencies": {
-        "@thumbtack/thumbprint-tokens": "^8.3.3",
+        "@thumbtack/thumbprint-tokens": "^12.1.1",
         "autoprefixer": "^9.0.1",
         "cssnano": "^4.1.0",
         "node-sass": "^4.9.2",

--- a/packages/thumbprint-react/CHANGELOG.md
+++ b/packages/thumbprint-react/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   [Major] The `Image` component `objectFit` prop will work even if the `height` prop is not used. This allows for use of `objectFit` while setting a height using `style` or `className`. Consumers should check that instances of `Image` that used the `objectFit` prop but didn't use the `height` prop render as expected. This should be uncommon since `objectFit` previously wouldn't have done anything.
 
+### Fixed
+
+-   [Patch] Upgrade Thumbprint Tokens to latest version. This pulls in small color tweaks to improve accessibility.
+
 ## 13.0.0 - 2020-07-07
 
 ### Changed

--- a/packages/thumbprint-react/components/Avatar/__snapshots__/test.tsx.snap
+++ b/packages/thumbprint-react/components/Avatar/__snapshots__/test.tsx.snap
@@ -220,7 +220,7 @@ exports[`adds the \`fullName\` as \`title\` text 3`] = `
       style={
         Object {
           "backgroundColor": "#fdf7e7",
-          "color": "#8a5500",
+          "color": "#714601",
         }
       }
       title="Avatar for Duck Goose"
@@ -276,7 +276,7 @@ exports[`does not render a badge by default 1`] = `
       style={
         Object {
           "backgroundColor": "#fdf7e7",
-          "color": "#8a5500",
+          "color": "#714601",
         }
       }
     >
@@ -305,7 +305,7 @@ exports[`does not render a badge by default 2`] = `
       style={
         Object {
           "backgroundColor": "#fdf7e7",
-          "color": "#8a5500",
+          "color": "#714601",
         }
       }
     >
@@ -376,7 +376,7 @@ exports[`renders a badge if valid badge prop is supplied 1`] = `
       style={
         Object {
           "backgroundColor": "#fdf7e7",
-          "color": "#8a5500",
+          "color": "#714601",
         }
       }
     >
@@ -434,7 +434,7 @@ exports[`renders a badge if valid badge prop is supplied 2`] = `
       style={
         Object {
           "backgroundColor": "#fdf7e7",
-          "color": "#8a5500",
+          "color": "#714601",
         }
       }
     >
@@ -492,7 +492,7 @@ exports[`renders a badge if valid badge prop is supplied 3`] = `
       style={
         Object {
           "backgroundColor": "#fdf7e7",
-          "color": "#8a5500",
+          "color": "#714601",
         }
       }
     >
@@ -538,7 +538,7 @@ exports[`renders an SVG when \`isChecked\` is true 1`] = `
       style={
         Object {
           "backgroundColor": "#fdf7e7",
-          "color": "#8a5500",
+          "color": "#714601",
         }
       }
     >
@@ -596,7 +596,7 @@ exports[`renders an SVG when \`isChecked\` is true 2`] = `
       style={
         Object {
           "backgroundColor": "#fdf7e7",
-          "color": "#8a5500",
+          "color": "#714601",
         }
       }
     >

--- a/packages/thumbprint-react/package.json
+++ b/packages/thumbprint-react/package.json
@@ -36,7 +36,7 @@
     "homepage": "https://github.com/thumbtack/thumbprint/blob/master/packages/thumbprint-react/",
     "dependencies": {
         "@thumbtack/thumbprint-scss": "^4.0.0",
-        "@thumbtack/thumbprint-tokens": "^11.0.0",
+        "@thumbtack/thumbprint-tokens": "^12.1.1",
         "classnames": "^2.2.6",
         "date-fns": "^1.28.5",
         "focus-trap": "4.0.2",

--- a/packages/thumbprint-scss/CHANGELOG.md
+++ b/packages/thumbprint-scss/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+-   [Patch] Upgrade Thumbprint Tokens to latest version. This pulls in small color tweaks to improve accessibility.
+
 ## 4.0.0 - 2019-11-21
 
 ### Removed

--- a/packages/thumbprint-scss/__snapshots__/test.js.snap
+++ b/packages/thumbprint-scss/__snapshots__/test.js.snap
@@ -35,12 +35,12 @@ exports[`compiles correctly 1`] = `
 }
 .tp-alert--warning {
   background: #ffebb3;
-  color: #8a5500;
+  color: #714601;
 }
 .tp-alert--warning a,
 .tp-alert--warning a:hover {
-  color: #8a5500;
-  fill: #8a5500;
+  color: #714601;
+  fill: #714601;
 }
 .tp-alert--note {
   background: #009fd9;
@@ -200,7 +200,7 @@ exports[`compiles correctly 1`] = `
   color: #ff5a5f;
 }
 .tp-button--caution:focus {
-  color: #cc3553;
+  color: #b22d31;
   background-color: #fff;
   border-color: #d3d4d5;
 }

--- a/packages/thumbprint-scss/package.json
+++ b/packages/thumbprint-scss/package.json
@@ -30,7 +30,7 @@
         "prepublishOnly": "../../scripts/should-build-package.js -- yarn start"
     },
     "devDependencies": {
-        "@thumbtack/thumbprint-tokens": "^8.3.3",
+        "@thumbtack/thumbprint-tokens": "^12.1.1",
         "autoprefixer": "^9.0.1",
         "cssnano": "^4.1.0",
         "fs-extra": "^8.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17892,7 +17892,7 @@ react-dnd@^7.3.2:
     invariant "^2.1.0"
     shallowequal "^1.1.0"
 
-react-docgen@^5.0.0:
+react-docgen@5.0.0, react-docgen@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/react-docgen/-/react-docgen-5.0.0.tgz#2a1fd50b32fc9ef4e04970e0b3ebc0387c319fea"
   integrity sha512-fToU6m0Cvx+L937lfx453/6RNUuxAq2BMop17c8juUJIwKZey3L5M2ZojawgMVnZYkJDBs0hVfHU9W7CaDUNGg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3387,21 +3387,13 @@
   dependencies:
     tslib "^1.10.0"
 
-"@thumbtack/thumbprint-tokens@^11.0.0":
-  version "11.0.0"
-  resolved "https://registry.yarnpkg.com/@thumbtack/thumbprint-tokens/-/thumbprint-tokens-11.0.0.tgz#6ae1f957f3c81b57b5d9d3434240d831aee8a582"
-  integrity sha512-xDBZsvjwJsm2Uc6jLHVRAmG2ag5qgPUHj5KQdsBD1eqlJ/EwDljyU+snfRLXOXn670O7NVcFea+E5N587pcdfg==
+"@thumbtack/thumbprint-tokens@^12.1.1":
+  version "12.1.1"
+  resolved "https://registry.yarnpkg.com/@thumbtack/thumbprint-tokens/-/thumbprint-tokens-12.1.1.tgz#b91569f1cd870834d905f9c3114e1ae6221b8a79"
+  integrity sha512-IPlYaTBS2a2t5Yn5KutIYycHVdJLZDbUcE7FW0AtutLMxE03+7fpV4BrfYSYA2/SBG8rGPINN9Rr/biOgNo5bw==
   dependencies:
     apollo-server-lambda "^2.9.7"
     graphql "^14.5.8"
-
-"@thumbtack/thumbprint-tokens@^8.3.3":
-  version "8.3.3"
-  resolved "https://registry.yarnpkg.com/@thumbtack/thumbprint-tokens/-/thumbprint-tokens-8.3.3.tgz#9c7aa9b83099c16a452db1c26b53f2d1acbd4e68"
-  integrity sha512-WD6QGhLLVNdDegIbPAarYqAG6aEFQ0H66DG5sXT7SkNlJIu7ZPTlicgsZBs4J6A28TuCFxubtfZvU1Blnpbe5Q==
-  dependencies:
-    jszip "^3.2.2"
-    number-to-words "^1.2.4"
 
 "@types/accepts@*":
   version "1.3.5"
@@ -13794,16 +13786,6 @@ jsx-ast-utils@^2.2.3:
     array-includes "^3.0.3"
     object.assign "^4.1.0"
 
-jszip@^3.2.2:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/jszip/-/jszip-3.2.2.tgz#b143816df7e106a9597a94c77493385adca5bd1d"
-  integrity sha512-NmKajvAFQpbg3taXQXr/ccS2wcucR1AZ+NtyWp2Nq7HHVsXhcJFR8p0Baf32C2yVvBylFWVeKf+WI2AnvlPhpA==
-  dependencies:
-    lie "~3.3.0"
-    pako "~1.0.2"
-    readable-stream "~2.3.6"
-    set-immediate-shim "~1.0.1"
-
 jwt-decode@^2.1.0, jwt-decode@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/jwt-decode/-/jwt-decode-2.2.0.tgz#7d86bd56679f58ce6a84704a657dd392bba81a79"
@@ -13975,13 +13957,6 @@ lie@3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/lie/-/lie-3.1.1.tgz#9a436b2cc7746ca59de7a41fa469b3efb76bd87e"
   integrity sha1-mkNrLMd0bKWd56QfpGmz77dr2H4=
-  dependencies:
-    immediate "~3.0.5"
-
-lie@~3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/lie/-/lie-3.3.0.tgz#dcf82dee545f46074daf200c7c1c5a08e0f40f6a"
-  integrity sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==
   dependencies:
     immediate "~3.0.5"
 
@@ -15915,11 +15890,6 @@ number-is-nan@^1.0.0:
   resolved "https://registry.yarnpkg.com/number-is-nan/-/number-is-nan-1.0.1.tgz#097b602b53422a522c1afb8790318336941a011d"
   integrity sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=
 
-number-to-words@^1.2.4:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/number-to-words/-/number-to-words-1.2.4.tgz#e0f124de9628f8d86c4eeb89bac6c07699264501"
-  integrity sha512-/fYevVkXRcyBiZDg6yzZbm0RuaD6i0qRfn8yr+6D0KgBMOndFPxuW10qCHpzs50nN8qKuv78k8MuotZhcVX6Pw==
-
 nwsapi@^2.0.7:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.1.4.tgz#e006a878db23636f8e8a67d33ca0e4edf61a842f"
@@ -16428,7 +16398,7 @@ package-json@^6.3.0:
     registry-url "^5.0.0"
     semver "^6.2.0"
 
-pako@~1.0.2, pako@~1.0.5:
+pako@~1.0.5:
   version "1.0.10"
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.10.tgz#4328badb5086a426aa90f541977d4955da5c9732"
   integrity sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw==
@@ -17922,7 +17892,7 @@ react-dnd@^7.3.2:
     invariant "^2.1.0"
     shallowequal "^1.1.0"
 
-react-docgen@5.0.0, react-docgen@^5.0.0:
+react-docgen@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/react-docgen/-/react-docgen-5.0.0.tgz#2a1fd50b32fc9ef4e04970e0b3ebc0387c319fea"
   integrity sha512-fToU6m0Cvx+L937lfx453/6RNUuxAq2BMop17c8juUJIwKZey3L5M2ZojawgMVnZYkJDBs0hVfHU9W7CaDUNGg==
@@ -19879,10 +19849,6 @@ set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
-
-set-immediate-shim@~1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz#4b2b1b27eb808a9f8dcc481a58e5e56f599f3f61"
 
 set-value@^2.0.0, set-value@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
The latest version includes some small color tweaks to improve accessibility. Here's an example of the difference:

* https://thumbprint.design/components/avatar/react/#section-avatars-without-images
* https://deploy-preview-700--thumbprint.netlify.app/components/avatar/react/#section-avatars-without-images

Notice that the letters in the deploy preview are slightly darker.