### PR TITLE
Upgrade Typescript and improve build scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
         "start": "echo \"\n👋 New to Thumbprint? Take a look at our 'CONTRIBUTING.md' for tips!\n\" && yarn run bootstrap && echo \"\nℹ️  Need a hand? Reach out on #design-systems for help.\n\" && yarn workspace www start",
         "start:ssr": "yarn run build:docs && yarn workspace www serve",
         "updated": "lerna updated",
-        "bootstrap": "lerna run prepublishOnly",
+        "bootstrap": "yarn install && lerna run prepublishOnly",
         "publish": "git checkout master && git pull && yarn && yarn test && yarn build:dist && lerna publish",
         "build:docs": "yarn run bootstrap && yarn workspace www build",
         "build:dist": "lerna exec -- rm -rf dist .cache && yarn run bootstrap",
@@ -12,7 +12,7 @@
         "test": "yarn run bootstrap && yarn run test:lint && yarn run test:jest && yarn run test:prettier && yarn test:typecheck",
         "test:jest": "TZ=America/Los_Angeles jest",
         "test:jest:watch": "yarn run bootstrap && yarn test:jest --watch",
-        "test:prettier": "./scripts/test-prettier.sh",
+        "test:prettier": "prettier \"**/*.{ts,tsx,js,jsx,css,scss,json,md,mdx,html}\" --check",
         "test:lint": "yarn test:lint:css && yarn test:lint:js",
         "test:lint:css": "stylelint \"**/*.scss\" \"**/*.css\" --ignore-path .gitignore",
         "test:lint:js": "eslint . --ignore-path .gitignore --ext .jsx,.js,.tsx,.ts",
@@ -74,7 +74,7 @@
         "stylelint-config-recommended-scss": "^3.3.0",
         "stylelint-scss": "^3.11.0",
         "tslib": "^1.10.0",
-        "typescript": "3.8.3"
+        "typescript": "3.9.6"
     },
     "repository": {
         "type": "git",

--- a/scripts/test-prettier.sh
+++ b/scripts/test-prettier.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-yarn prettier "**/*.{ts,tsx,js,jsx,css,scss,json,md,mdx,html}" --list-different || (c=$?; echo "
-⚠️  Some files in this branch have not been formatted with Prettier. Please run 'yarn run format' to format them.
-"; (exit $c))

--- a/yarn.lock
+++ b/yarn.lock
@@ -21705,10 +21705,10 @@ typescript@3.6.2:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.2.tgz#105b0f1934119dde543ac8eb71af3a91009efe54"
   integrity sha512-lmQ4L+J6mnu3xweP8+rOrUwzmN+MRAj7TgtJtDaXE5PMyX2kCrklhg3rvOsOIfNeAWMQWO2F1GPc1kMD2vLAfw==
 
-typescript@3.8.3:
-  version "3.8.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
-  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
+typescript@3.9.6:
+  version "3.9.6"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.6.tgz#8f3e0198a34c3ae17091b35571d3afd31999365a"
+  integrity sha512-Pspx3oKAPJtjNwE92YS05HQoY7z2SFyOpHo9MqJor3BXAGNaPUs83CuVp9VISFkSjyRfiTpmKuAYGJB7S7hOxw==
 
 typescript@^3.9.3:
   version "3.9.5"


### PR DESCRIPTION
- Upgrade TypeScript to version 3.9.6. This gives access to null
  coalescing operator

- Remove the custom prettier check script and just `prettier --check`

- Run `yarn install` as part of `yarn bootstrap`. This ensures that
  `yarn start` and `yarn test` will never try to run with outdated
  dependencies (which can cause the build or tests to fail).