### PR TITLE
Use `ref` for ModalCurtain's `initialFocus` prop

### DIFF
--- a/packages/thumbprint-react/components/ModalCurtain/index.tsx
+++ b/packages/thumbprint-react/components/ModalCurtain/index.tsx
@@ -57,14 +57,14 @@ interface PropTypes {
      * A selector for the element that should be focused when the modal opens. If omitted, the
      * entire container element of the modal is focused.
      */
-    initialFocus?: string;
+    initialFocus?: HTMLElement;
 }
 
 export default function ModalCurtain({
     stage = 'exited',
     shouldCloseOnEscape = true,
     accessibilityLabel = 'Modal',
-    initialFocus,
+    initialFocus: initialFocusProp,
     onCloseClick,
     children,
 }: PropTypes): JSX.Element {
@@ -75,20 +75,15 @@ export default function ModalCurtain({
         setIsClient(true);
     }, []);
 
-    let elementToFocus: HTMLElement | null = null;
-    if (initialFocus && wrapperEl) {
-        elementToFocus = (wrapperEl.querySelector(initialFocus) as HTMLElement) || null;
-    }
+    const initialFocus = initialFocusProp || wrapperEl;
 
     const isEnteringOrEntered = stage === 'entering' || stage === 'entered';
     const shouldBindEscListener = isClient && shouldCloseOnEscape && isEnteringOrEntered;
-    const shouldTrapFocus = isClient && elementToFocus !== null && stage === 'entered';
+    const shouldTrapFocus = isClient && !!initialFocus && stage === 'entered';
     const shouldDisableScrolling = isEnteringOrEntered;
 
-    // console.log(elementToFocus);
-
     useCloseOnEscape(onCloseClick, shouldBindEscListener);
-    useFocusTrap(wrapperEl, shouldTrapFocus, elementToFocus);
+    useFocusTrap(wrapperEl, shouldTrapFocus, initialFocus);
 
     return (
         <ConditionalPortal shouldDisplace>

--- a/packages/thumbprint-react/components/ModalCurtain/test.tsx
+++ b/packages/thumbprint-react/components/ModalCurtain/test.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import { mount } from 'enzyme';
 import ModalCurtain from './index';
 
@@ -118,18 +118,28 @@ describe('ModalCurtain', () => {
 
     test.only('initially focuses `initialFocus` element if provided', () => {
         jest.useFakeTimers();
-
         const onCloseClick = jest.fn();
-        const wrapper = mount(
-            <ModalCurtain stage="entered" onCloseClick={onCloseClick} initialFocus="#initial-input">
-                {(): JSX.Element => (
-                    <>
-                        <button type="button" />
-                        <input id="initial-input" />
-                    </>
-                )}
-            </ModalCurtain>,
-        );
+
+        const Example = (): React.ReactElement => {
+            const buttonRef = useRef<HTMLButtonElement>(null);
+
+            return (
+                <ModalCurtain
+                    stage="entered"
+                    onCloseClick={onCloseClick}
+                    initialFocus={buttonRef.current !== null ? buttonRef.current : undefined}
+                >
+                    {(): JSX.Element => (
+                        <>
+                            <button type="button" ref={buttonRef} />
+                            <input id="initial-input" />
+                        </>
+                    )}
+                </ModalCurtain>
+            );
+        };
+
+        const wrapper = mount(<Example />);
 
         // Run setTimeouts() in focus-trap to completion
         jest.runAllTimers();

--- a/packages/thumbprint-react/components/Popover/index.tsx
+++ b/packages/thumbprint-react/components/Popover/index.tsx
@@ -84,7 +84,7 @@ export default function Popover({
     const shouldBindEscListener: boolean = canUseDOM && isOpen;
 
     useCloseOnEscape(onCloseClick, shouldBindEscListener);
-    useFocusTrap(wrapperEl, shouldTrapFocus);
+    useFocusTrap(wrapperEl, shouldTrapFocus, wrapperEl);
 
     return (
         <Manager>

--- a/packages/thumbprint-react/utils/use-focus-trap.ts
+++ b/packages/thumbprint-react/utils/use-focus-trap.ts
@@ -20,20 +20,18 @@ function toggleTrap(trap: FocusTrap, isActive: boolean): void {
 export default function useFocusTrap(
     element: HTMLElement | null,
     isActive = false,
-    initialFocus?: HTMLElement | null,
+    initialFocus: HTMLElement | null,
 ): void {
     const [trap, setTrap] = useState<FocusTrap>();
 
     const initialFocusElement = initialFocus || element;
-
-    console.log('focusing on', initialFocusElement ? initialFocusElement.type : undefined);
 
     useEffect((): (() => void) => {
         // If we've already created a trap, toggle it based on the isActive status
         if (trap) {
             toggleTrap(trap, isActive);
             // Otherwise, if there's no trap, but there is a valid element that needs to be trapped
-        } else if (element) {
+        } else if (element && initialFocusElement && isActive) {
             // Create the trap and store a reference to it
             const newTrap = createFocusTrap(element, {
                 clickOutsideDeactivates: true,

--- a/www/src/pages/components/modal-curtain/react/index.mdx
+++ b/www/src/pages/components/modal-curtain/react/index.mdx
@@ -85,6 +85,7 @@ By default the curtain will focus on the container when it opens. If your modal 
 function ModalCurtainDemo() {
     const [isOpen, setIsOpen] = React.useState(false);
     const [textValue, setTextValue] = React.useState('hello');
+    const inputEl = React.useRef();
 
     return (
         <div>
@@ -93,16 +94,21 @@ function ModalCurtainDemo() {
             <ModalCurtain
                 stage={isOpen ? 'entered' : 'exited'}
                 onCloseClick={() => setIsOpen(false)}
-                initialFocus="#initial-input"
+                initialFocus={inputEl && inputEl.current}
             >
                 {({ curtainClassName, curtainOnClick }) => (
-                    <div className={`pa4 ${curtainClassName}`}>
+                    <div
+                        onClick={curtainOnClick}
+                        className={`pa4 ${curtainClassName}`}
+                        style={{ backgroundColor: 'rgba(0, 0, 0, 0.5)' }}
+                    >
                         <div className="bg-white ma-auto pa4 mw7">
                             <div className="mt4">
-                                <TextInput
+                                <input
                                     value={textValue}
                                     id="initial-input"
                                     onChange={value => setTextValue(value)}
+                                    ref={inputEl}
                                 />
                                 <Button onClick={() => setIsOpen(false)}>Close Modal</Button>
                             </div>


### PR DESCRIPTION
The test is still failing, but throwing this up mostly as an example.