### PR TITLE
Use Coda API v1.

### DIFF
--- a/packages/gatsby-source-coda/gatsby-node.js
+++ b/packages/gatsby-source-coda/gatsby-node.js
@@ -17,8 +17,8 @@ exports.sourceNodes = async ({ actions }, { apiToken, docId, tableIdOrName, useC
 
     try {
         listRowsRes = await fetch(
-            // https://coda.io/developers/apis/v1beta1#operation/listRows
-            `https://coda.io/apis/v1beta1/docs/${docId}/tables/${tableIdOrName}/rows?${qs}`,
+            // https://coda.io/developers/apis/v1#operation/listRows
+            `https://coda.io/apis/v1/docs/${docId}/tables/${tableIdOrName}/rows?${qs}`,
             {
                 headers: {
                     Authorization: `Bearer ${apiToken}`,


### PR DESCRIPTION
Coda launched the v1 of their API last week. In a few weeks they'll be turning off the beta API endpoint:
https://community.coda.io/t/launched-coda-api-v1/17248/1

We currently use the API for the `/components/overview` page and I've verified that it works with these changes.