### PR TITLE
Remove `react-docgen` from resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,8 +113,5 @@
         "hooks": {
             "pre-commit": "pretty-quick --staged"
         }
-    },
-    "resolutions": {
-        "react-docgen": "5.0.0"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -17892,7 +17892,7 @@ react-dnd@^7.3.2:
     invariant "^2.1.0"
     shallowequal "^1.1.0"
 
-react-docgen@5.0.0, react-docgen@^5.0.0:
+react-docgen@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/react-docgen/-/react-docgen-5.0.0.tgz#2a1fd50b32fc9ef4e04970e0b3ebc0387c319fea"
   integrity sha512-fToU6m0Cvx+L937lfx453/6RNUuxAq2BMop17c8juUJIwKZey3L5M2ZojawgMVnZYkJDBs0hVfHU9W7CaDUNGg==


### PR DESCRIPTION
We no longer need to enforce this new version because Gatsby has upgraded its version.

Fixes #604.