### PR TITLE
Add CODEOWNERS for iOS and Android docs.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+/www/src/pages/components/*/ios/* @kevinmbeaulieu @danoc
+/www/src/pages/components/*/android/* @mallikapotter @danoc


### PR DESCRIPTION
I think this is the right syntax! Here's more info:
https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax

We can make a test PR after merging this.