### PR TITLE
Use same version of TypeScript in both package.json files (1/2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
         "stylelint-config-recommended-scss": "^3.3.0",
         "stylelint-scss": "^3.11.0",
         "tslib": "^1.10.0",
-        "typescript": "3.9.6"
+        "typescript": "^3.9.6"
     },
     "repository": {
         "type": "git",

--- a/packages/thumbprint-react/CHANGELOG.md
+++ b/packages/thumbprint-react/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+-   [Patch] Use newer version of TypeScript as dev dependency.
+
 ## 14.0.0 - 2020-07-14
 
 ### Changed

--- a/packages/thumbprint-react/components/Image/test.tsx
+++ b/packages/thumbprint-react/components/Image/test.tsx
@@ -47,7 +47,7 @@ test('creates two IntersectionObserver instances if there are two scrollable par
 test('creates three IntersectionObserver instances if there are three scrollable parents', () => {
     mount(
         <React.Fragment>
-            <header style={{ overflowX: 'scroll' }}>Header</header>
+            <header css={{ overflowX: 'scroll' }}>Header</header>
             <main style={{ overflowX: 'auto' }}>
                 <div>
                     <div style={{ overflowX: 'scroll' }}>

--- a/packages/thumbprint-react/components/Image/test.tsx
+++ b/packages/thumbprint-react/components/Image/test.tsx
@@ -47,7 +47,7 @@ test('creates two IntersectionObserver instances if there are two scrollable par
 test('creates three IntersectionObserver instances if there are three scrollable parents', () => {
     mount(
         <React.Fragment>
-            <header css={{ overflowX: 'scroll' }}>Header</header>
+            <header style={{ overflowX: 'scroll' }}>Header</header>
             <main style={{ overflowX: 'auto' }}>
                 <div>
                     <div style={{ overflowX: 'scroll' }}>

--- a/packages/thumbprint-react/package.json
+++ b/packages/thumbprint-react/package.json
@@ -62,6 +62,6 @@
         "rollup-plugin-node-resolve": "^5.2.0",
         "rollup-plugin-typescript": "^1.0.1",
         "tslib": "^1.10.0",
-        "typescript": "3.6.2"
+        "typescript": "^3.9.6"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -20107,20 +20107,15 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@3.6.2:
-  version "3.6.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.2.tgz#105b0f1934119dde543ac8eb71af3a91009efe54"
-  integrity sha512-lmQ4L+J6mnu3xweP8+rOrUwzmN+MRAj7TgtJtDaXE5PMyX2kCrklhg3rvOsOIfNeAWMQWO2F1GPc1kMD2vLAfw==
-
-typescript@3.9.6:
-  version "3.9.6"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.6.tgz#8f3e0198a34c3ae17091b35571d3afd31999365a"
-  integrity sha512-Pspx3oKAPJtjNwE92YS05HQoY7z2SFyOpHo9MqJor3BXAGNaPUs83CuVp9VISFkSjyRfiTpmKuAYGJB7S7hOxw==
-
 typescript@^3.9.3:
   version "3.9.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.5.tgz#586f0dba300cde8be52dd1ac4f7e1009c1b13f36"
   integrity sha512-hSAifV3k+i6lEoCJ2k6R2Z/rp/H3+8sdmcn5NrS3/3kE7+RyZXm9aqvxWqjEXHAd8b0pShatpcdMTvEdvAJltQ==
+
+typescript@^3.9.6:
+  version "3.9.7"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
+  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
 
 ua-parser-js@^0.7.18:
   version "0.7.20"


### PR DESCRIPTION
This was package upgrades to fail with the error:

```
could not find a copy of typescript to link
```

I don't entirely know what it means, but using a single version of TypeScript fixed the issue. A few people have run into the same issue and there's various proposed workarounds: https://github.com/yarnpkg/yarn/issues/6285