### PR TITLE
Add `dataTestId` props and deprecate `dataTest`.

### DIFF
--- a/packages/thumbprint-react/CHANGELOG.md
+++ b/packages/thumbprint-react/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 -   [Minor] Add an `initialFocus` to `ModalCurtain`.
+-   [Minor] Add `dataTestId` props to components that previously supported `dataTest`. `dataTest` is now deprecated. (#724)
 
 ## 14.1.0 - 2020-10-05
 

--- a/packages/thumbprint-react/components/Alert/__snapshots__/test.tsx.snap
+++ b/packages/thumbprint-react/components/Alert/__snapshots__/test.tsx.snap
@@ -9,7 +9,7 @@ exports[`BannerAlert renders children 1`] = `
       className="text"
     >
       <p
-        data-test-id="text"
+        data-testid="text"
       >
         Alert content
       </p>
@@ -49,7 +49,7 @@ exports[`InPageAlert renders children 1`] = `
       className="text"
     >
       <p
-        data-test-id="text"
+        data-testid="text"
       >
         Alert content
       </p>

--- a/packages/thumbprint-react/components/Alert/index.tsx
+++ b/packages/thumbprint-react/components/Alert/index.tsx
@@ -16,12 +16,18 @@ interface BannerPropTypes {
     /**
      * A selector to hook into the React component for use in automated testing environments.
      */
+    dataTestId?: string;
+    /**
+     * A selector to hook into the React component for use in automated testing environments.
+     * @deprecated
+     */
     dataTest?: string;
 }
 
 export function BannerAlert({
     children = null,
     theme = 'info',
+    dataTestId,
     dataTest,
 }: BannerPropTypes): JSX.Element {
     return (
@@ -34,6 +40,7 @@ export function BannerAlert({
                 [styles.warning]: theme === 'warning',
                 [styles.info]: theme === 'info',
             })}
+            data-testid={dataTestId}
             data-test={dataTest}
         >
             <div className={styles.text}>{children}</div>
@@ -53,6 +60,11 @@ interface InPagePropTypes {
     /**
      * A selector to hook into the React component for use in automated testing environments.
      */
+    dataTestId?: string;
+    /**
+     * A selector to hook into the React component for use in automated testing environments.
+     * @deprecated
+     */
     dataTest?: string;
 }
 
@@ -67,6 +79,7 @@ export function InPageAlert({
     children = null,
     theme = 'info',
     dataTest,
+    dataTestId,
 }: InPagePropTypes): JSX.Element {
     return (
         <div
@@ -77,6 +90,7 @@ export function InPageAlert({
                 [styles.warning]: theme === 'warning',
                 [styles.info]: theme === 'info',
             })}
+            data-testid={dataTestId}
             data-test={dataTest}
         >
             {ALERT_ICONS[theme]}

--- a/packages/thumbprint-react/components/Alert/test.tsx
+++ b/packages/thumbprint-react/components/Alert/test.tsx
@@ -6,10 +6,10 @@ describe('BannerAlert', () => {
     test('renders children', () => {
         const wrapper = mount(
             <BannerAlert>
-                <p data-test-id="text">Alert content</p>
+                <p data-testid="text">Alert content</p>
             </BannerAlert>,
         );
-        expect(wrapper.find('[data-test-id="text"]').text()).toBe('Alert content');
+        expect(wrapper.find('[data-testid="text"]').text()).toBe('Alert content');
         expect(wrapper).toMatchSnapshot();
     });
 });
@@ -27,10 +27,10 @@ describe('InPageAlert', () => {
     test('renders children', () => {
         const wrapper = mount(
             <InPageAlert>
-                <p data-test-id="text">Alert content</p>
+                <p data-testid="text">Alert content</p>
             </InPageAlert>,
         );
-        expect(wrapper.find('[data-test-id="text"]').text()).toBe('Alert content');
+        expect(wrapper.find('[data-testid="text"]').text()).toBe('Alert content');
         expect(wrapper).toMatchSnapshot();
     });
 });

--- a/packages/thumbprint-react/components/AlertBanner/__snapshots__/test.tsx.snap
+++ b/packages/thumbprint-react/components/AlertBanner/__snapshots__/test.tsx.snap
@@ -33,7 +33,7 @@ exports[`AlertBanner match snapshot 1`] = `
     </WarningFilled>
     <div>
       <div
-        data-test="child"
+        data-testid="child"
       >
         This is the child component.
         <a
@@ -80,7 +80,7 @@ exports[`AlertBanner match snapshot 2`] = `
     </InfoFilled>
     <div>
       <div
-        data-test="child"
+        data-testid="child"
       >
         This is the child component.
         <a
@@ -127,7 +127,7 @@ exports[`AlertBanner match snapshot 3`] = `
     </BlockedFilled>
     <div>
       <div
-        data-test="child"
+        data-testid="child"
       >
         This is the child component.
         <a

--- a/packages/thumbprint-react/components/AlertBanner/index.tsx
+++ b/packages/thumbprint-react/components/AlertBanner/index.tsx
@@ -15,6 +15,11 @@ interface AlertBannerPropTypes {
     /**
      * A selector to hook into the React component for use in automated testing environments.
      */
+    dataTestId?: string;
+    /**
+     * A selector to hook into the React component for use in automated testing environments.
+     * @deprecated
+     */
     dataTest?: string;
 }
 
@@ -27,6 +32,7 @@ const ALERT_ICONS = {
 export default function AlertBanner({
     children,
     theme,
+    dataTestId,
     dataTest,
 }: AlertBannerPropTypes): JSX.Element {
     return (
@@ -37,6 +43,7 @@ export default function AlertBanner({
                 [styles.info]: theme === 'info',
                 [styles.warning]: theme === 'warning',
             })}
+            data-testid={dataTestId}
             data-test={dataTest}
         >
             {ALERT_ICONS[theme]}

--- a/packages/thumbprint-react/components/AlertBanner/test.tsx
+++ b/packages/thumbprint-react/components/AlertBanner/test.tsx
@@ -6,7 +6,7 @@ import { BlockedFilled, InfoFilled, WarningFilled } from '../../icons';
 
 describe('AlertBanner', () => {
     const children = (
-        <div data-test="child">
+        <div data-testid="child">
             This is the child component.
             <a href="/">Click here</a>
         </div>
@@ -49,11 +49,21 @@ describe('AlertBanner', () => {
     });
 
     test('renders children', () => {
-        expect(cautionWrapper.find('[data-test="child"]').length).toBe(1);
+        expect(cautionWrapper.find('[data-testid="child"]').length).toBe(1);
     });
 
     test('appends data-test attribute to root', () => {
         expect(cautionWrapper.find('[data-test="test"]').hasClass('root')).toBe(true);
+    });
+
+    test('appends data-testid attribute to root', () => {
+        const wrapper = mount(
+            <AlertBanner theme="caution" dataTestId="test">
+                {children}
+            </AlertBanner>,
+        );
+
+        expect(wrapper.find('[data-testid="test"]').hasClass('root')).toBe(true);
     });
 
     test('match snapshot', () => {

--- a/packages/thumbprint-react/components/Button/__snapshots__/test.tsx.snap
+++ b/packages/thumbprint-react/components/Button/__snapshots__/test.tsx.snap
@@ -51,6 +51,57 @@ exports[`adds \`dataTest\` prop 2`] = `
 </ForwardRef>
 `;
 
+exports[`adds \`dataTestId\` prop 1`] = `
+<ForwardRef
+  dataTestId="Duck"
+>
+  <ForwardRef
+    dataTestId="Duck"
+    isDisabled={false}
+    isLoading={false}
+    size="large"
+    theme="primary"
+    type="button"
+    width="auto"
+  >
+    <button
+      className="themedButton themedButtonRoundedBordersLeft themedButtonRoundedBordersRight themedButtonThemePrimary themedButtonWidthAuto"
+      data-testid="Duck"
+      disabled={false}
+      type="button"
+    >
+      <span
+        className="flexWrapper flexWrapperSizeLarge"
+      >
+        Goose
+      </span>
+    </button>
+  </ForwardRef>
+</ForwardRef>
+`;
+
+exports[`adds \`dataTestId\` prop 2`] = `
+<ForwardRef
+  dataTestId="Duck"
+>
+  <ForwardRef
+    dataTestId="Duck"
+    isDisabled={false}
+    theme="primary"
+    type="button"
+  >
+    <button
+      className="plain plainThemePrimary"
+      data-testid="Duck"
+      disabled={false}
+      type="button"
+    >
+      Goose
+    </button>
+  </ForwardRef>
+</ForwardRef>
+`;
+
 exports[`renders button of type \`button\` by default 1`] = `
 <ForwardRef>
   <ForwardRef

--- a/packages/thumbprint-react/components/Button/index.tsx
+++ b/packages/thumbprint-react/components/Button/index.tsx
@@ -15,6 +15,7 @@ interface CommonProps {
     theme?: 'primary' | 'secondary' | 'tertiary' | 'inherit';
     type?: 'button' | 'submit';
     dataTest?: string;
+    dataTestId?: string;
     accessibilityLabel?: string;
 }
 
@@ -30,6 +31,7 @@ const getCommonProps = (props: CommonProps): CommonProps => ({
     onBlur: props.onBlur,
     accessibilityLabel: props.accessibilityLabel,
     dataTest: props.dataTest,
+    dataTestId: props.dataTestId,
 });
 
 const TextButton = React.forwardRef<HTMLButtonElement, TextButtonPropTypes>(
@@ -49,6 +51,7 @@ const TextButton = React.forwardRef<HTMLButtonElement, TextButtonPropTypes>(
             theme = 'primary',
             type = 'button',
             dataTest,
+            dataTestId,
         }: TextButtonPropTypes,
         ref,
     ): JSX.Element => (
@@ -65,6 +68,7 @@ const TextButton = React.forwardRef<HTMLButtonElement, TextButtonPropTypes>(
                 onBlur,
                 accessibilityLabel,
                 dataTest,
+                dataTestId,
             })}
             theme={theme}
             iconLeft={iconLeft}
@@ -135,6 +139,11 @@ interface TextButtonPropTypes {
     /**
      * A selector hook into the React component for use in automated testing environments.
      */
+    dataTestId?: string;
+    /**
+     * A selector hook into the React component for use in automated testing environments.
+     * @deprecated
+     */
     dataTest?: string;
 }
 
@@ -158,6 +167,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonPropTypes>(
             size = 'large',
             width = 'auto',
             dataTest,
+            dataTestId,
         }: ButtonPropTypes,
         ref,
     ): JSX.Element => (
@@ -174,6 +184,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonPropTypes>(
                 onBlur,
                 accessibilityLabel,
                 dataTest,
+                dataTestId,
             })}
             icon={icon}
             iconRight={iconRight}
@@ -260,6 +271,11 @@ interface ButtonPropTypes {
     width?: 'auto' | 'full' | 'full-below-small';
     /**
      * A selector hook into the React component for use in automated testing environments.
+     */
+    dataTestId?: string;
+    /**
+     * A selector hook into the React component for use in automated testing environments.
+     * @deprecated
      */
     dataTest?: string;
 }

--- a/packages/thumbprint-react/components/Button/test.tsx
+++ b/packages/thumbprint-react/components/Button/test.tsx
@@ -80,3 +80,13 @@ test('adds `dataTest` prop', (): void => {
     expect(wrapperB.find('button').prop('data-test')).toEqual('Duck');
     expect(wrapperB).toMatchSnapshot();
 });
+
+test('adds `dataTestId` prop', (): void => {
+    const wrapperA = mount(<Button dataTestId="Duck">Goose</Button>);
+    expect(wrapperA.find('button').prop('data-testid')).toEqual('Duck');
+    expect(wrapperA).toMatchSnapshot();
+
+    const wrapperB = mount(<TextButton dataTestId="Duck">Goose</TextButton>);
+    expect(wrapperB.find('button').prop('data-testid')).toEqual('Duck');
+    expect(wrapperB).toMatchSnapshot();
+});

--- a/packages/thumbprint-react/components/ButtonRow/__snapshots__/test.tsx.snap
+++ b/packages/thumbprint-react/components/ButtonRow/__snapshots__/test.tsx.snap
@@ -11,17 +11,6 @@ exports[`adds \`dataTest\` prop 1`] = `
 </ButtonRow>
 `;
 
-exports[`adds \`dataTest\` prop 2`] = `
-<ButtonRow
-  dataTestId="Duck"
->
-  <div
-    className="root justifyLeft"
-    data-testid="Duck"
-  />
-</ButtonRow>
-`;
-
 exports[`adds \`dataTestId\` prop 1`] = `
 <ButtonRow
   dataTestId="Duck"

--- a/packages/thumbprint-react/components/ButtonRow/__snapshots__/test.tsx.snap
+++ b/packages/thumbprint-react/components/ButtonRow/__snapshots__/test.tsx.snap
@@ -11,6 +11,17 @@ exports[`adds \`dataTest\` prop 1`] = `
 </ButtonRow>
 `;
 
+exports[`adds \`dataTest\` prop 2`] = `
+<ButtonRow
+  dataTestId="Duck"
+>
+  <div
+    className="root justifyLeft"
+    data-testid="Duck"
+  />
+</ButtonRow>
+`;
+
 exports[`placement center 1`] = `
 <ButtonRow
   justify="center"

--- a/packages/thumbprint-react/components/ButtonRow/__snapshots__/test.tsx.snap
+++ b/packages/thumbprint-react/components/ButtonRow/__snapshots__/test.tsx.snap
@@ -22,6 +22,17 @@ exports[`adds \`dataTest\` prop 2`] = `
 </ButtonRow>
 `;
 
+exports[`adds \`dataTestId\` prop 1`] = `
+<ButtonRow
+  dataTestId="Duck"
+>
+  <div
+    className="root justifyLeft"
+    data-testid="Duck"
+  />
+</ButtonRow>
+`;
+
 exports[`placement center 1`] = `
 <ButtonRow
   justify="center"

--- a/packages/thumbprint-react/components/ButtonRow/index.tsx
+++ b/packages/thumbprint-react/components/ButtonRow/index.tsx
@@ -19,12 +19,18 @@ interface PropTypes {
     /**
      * A selector hook into the React component for use in automated testing environments.
      */
+    dataTestId?: string;
+    /**
+     * A selector hook into the React component for use in automated testing environments.
+     * @deprecated
+     */
     dataTest?: string;
 }
 
 export default function ButtonRow({
     children = null,
     justify = 'left',
+    dataTestId,
     dataTest,
     isStackedBelowSmall = false,
 }: PropTypes): JSX.Element {
@@ -37,6 +43,7 @@ export default function ButtonRow({
                 [styles.justifyLeft]: justify === 'left',
                 [styles.justifyRight]: justify === 'right',
             })}
+            data-testid={dataTestId}
             data-test={dataTest}
         >
             {React.Children.map(children, child => (

--- a/packages/thumbprint-react/components/ButtonRow/test.tsx
+++ b/packages/thumbprint-react/components/ButtonRow/test.tsx
@@ -30,3 +30,9 @@ test('adds `dataTest` prop', () => {
     expect(wrapper.find('div').prop('data-test')).toEqual('Duck');
     expect(wrapper).toMatchSnapshot();
 });
+
+test('adds `dataTest` prop', () => {
+    const wrapper = mount(<ButtonRow dataTestId="Duck" />);
+    expect(wrapper.find('div').prop('data-testid')).toEqual('Duck');
+    expect(wrapper).toMatchSnapshot();
+});

--- a/packages/thumbprint-react/components/ButtonRow/test.tsx
+++ b/packages/thumbprint-react/components/ButtonRow/test.tsx
@@ -31,7 +31,7 @@ test('adds `dataTest` prop', () => {
     expect(wrapper).toMatchSnapshot();
 });
 
-test('adds `dataTest` prop', () => {
+test('adds `dataTestId` prop', () => {
     const wrapper = mount(<ButtonRow dataTestId="Duck" />);
     expect(wrapper.find('div').prop('data-testid')).toEqual('Duck');
     expect(wrapper).toMatchSnapshot();

--- a/packages/thumbprint-react/components/Carousel/test.tsx
+++ b/packages/thumbprint-react/components/Carousel/test.tsx
@@ -16,11 +16,11 @@ describe('Carousel', () => {
     test('does not render duplicate children when not animating', () => {
         const wrapper = mount(
             <Carousel selectedIndex={0} onSelectedIndexChange={noop}>
-                <div data-test="item">Goose</div>
+                <div data-testid="item">Goose</div>
             </Carousel>,
         );
 
-        expect(wrapper.find('[data-test="item"]')).toHaveLength(1);
+        expect(wrapper.find('[data-testid="item"]')).toHaveLength(1);
     });
 
     describe('`selectedIndex`', () => {

--- a/packages/thumbprint-react/components/Checkbox/__snapshots__/test.tsx.snap
+++ b/packages/thumbprint-react/components/Checkbox/__snapshots__/test.tsx.snap
@@ -96,6 +96,54 @@ exports[`adds \`dataTest\` prop 2`] = `
 </Checkbox>
 `;
 
+exports[`adds \`dataTestId\` prop 1`] = `
+<Checkbox
+  dataTestId="Duck"
+  onChange={[MockFunction]}
+>
+  <label
+    className="root rootCheckboxVerticalAlignCenter"
+    style={
+      Object {
+        "cursor": "pointer",
+        "padding": "14px 0",
+      }
+    }
+  >
+    <input
+      aria-checked={false}
+      checked={false}
+      className="input"
+      data-testid="Duck"
+      disabled={false}
+      onChange={[Function]}
+      required={false}
+      type="checkbox"
+    />
+    <div
+      className="checkboxImage"
+      style={
+        Object {
+          "backgroundColor": "#ffffff",
+          "borderColor": "#d3d4d5",
+          "color": "inherit",
+        }
+      }
+    />
+    <span
+      className="text"
+      style={
+        Object {
+          "color": "inherit",
+        }
+      }
+    >
+      Goose
+    </span>
+  </label>
+</Checkbox>
+`;
+
 exports[`adds \`disabled\` attribute 1`] = `
 <Checkbox
   isDisabled={true}

--- a/packages/thumbprint-react/components/Checkbox/__snapshots__/test.tsx.snap
+++ b/packages/thumbprint-react/components/Checkbox/__snapshots__/test.tsx.snap
@@ -48,54 +48,6 @@ exports[`adds \`dataTest\` prop 1`] = `
 </Checkbox>
 `;
 
-exports[`adds \`dataTest\` prop 2`] = `
-<Checkbox
-  dataTestId="Duck"
-  onChange={[MockFunction]}
->
-  <label
-    className="root rootCheckboxVerticalAlignCenter"
-    style={
-      Object {
-        "cursor": "pointer",
-        "padding": "14px 0",
-      }
-    }
-  >
-    <input
-      aria-checked={false}
-      checked={false}
-      className="input"
-      data-testid="Duck"
-      disabled={false}
-      onChange={[Function]}
-      required={false}
-      type="checkbox"
-    />
-    <div
-      className="checkboxImage"
-      style={
-        Object {
-          "backgroundColor": "#ffffff",
-          "borderColor": "#d3d4d5",
-          "color": "inherit",
-        }
-      }
-    />
-    <span
-      className="text"
-      style={
-        Object {
-          "color": "inherit",
-        }
-      }
-    >
-      Goose
-    </span>
-  </label>
-</Checkbox>
-`;
-
 exports[`adds \`dataTestId\` prop 1`] = `
 <Checkbox
   dataTestId="Duck"

--- a/packages/thumbprint-react/components/Checkbox/__snapshots__/test.tsx.snap
+++ b/packages/thumbprint-react/components/Checkbox/__snapshots__/test.tsx.snap
@@ -48,6 +48,54 @@ exports[`adds \`dataTest\` prop 1`] = `
 </Checkbox>
 `;
 
+exports[`adds \`dataTest\` prop 2`] = `
+<Checkbox
+  dataTestId="Duck"
+  onChange={[MockFunction]}
+>
+  <label
+    className="root rootCheckboxVerticalAlignCenter"
+    style={
+      Object {
+        "cursor": "pointer",
+        "padding": "14px 0",
+      }
+    }
+  >
+    <input
+      aria-checked={false}
+      checked={false}
+      className="input"
+      data-testid="Duck"
+      disabled={false}
+      onChange={[Function]}
+      required={false}
+      type="checkbox"
+    />
+    <div
+      className="checkboxImage"
+      style={
+        Object {
+          "backgroundColor": "#ffffff",
+          "borderColor": "#d3d4d5",
+          "color": "inherit",
+        }
+      }
+    />
+    <span
+      className="text"
+      style={
+        Object {
+          "color": "inherit",
+        }
+      }
+    >
+      Goose
+    </span>
+  </label>
+</Checkbox>
+`;
+
 exports[`adds \`disabled\` attribute 1`] = `
 <Checkbox
   isDisabled={true}

--- a/packages/thumbprint-react/components/Checkbox/index.tsx
+++ b/packages/thumbprint-react/components/Checkbox/index.tsx
@@ -154,6 +154,12 @@ interface PropTypes {
      * A selector hook into the React component for use in automated testing environments. It is
      * applied internally to the `<input />` element.
      */
+    dataTestId?: string;
+    /**
+     * A selector hook into the React component for use in automated testing environments. It is
+     * applied internally to the `<input />` element.
+     * @deprecated
+     */
     dataTest?: string;
     /**
      * Determines how the checkbox input will be vertically aligned relative to `props.children`.
@@ -170,6 +176,7 @@ export default function Checkbox({
     checkboxVerticalAlign = 'center',
     children,
     dataTest,
+    dataTestId,
     hasError = false,
     id,
     isChecked = false,
@@ -208,6 +215,7 @@ export default function Checkbox({
             <input
                 className={styles.input}
                 aria-checked={isIndeterminate ? 'mixed' : isChecked}
+                data-testid={dataTestId}
                 data-test={dataTest}
                 type="checkbox"
                 id={id}

--- a/packages/thumbprint-react/components/Checkbox/test.tsx
+++ b/packages/thumbprint-react/components/Checkbox/test.tsx
@@ -162,6 +162,16 @@ test('adds `dataTest` prop', () => {
     expect(wrapper).toMatchSnapshot();
 });
 
+test('adds `dataTest` prop', () => {
+    const wrapper = mount(
+        <Checkbox dataTestId="Duck" onChange={jest.fn()}>
+            Goose
+        </Checkbox>,
+    );
+    expect(wrapper.find('input').prop('data-testid')).toEqual('Duck');
+    expect(wrapper).toMatchSnapshot();
+});
+
 test('adds `value` prop', () => {
     const wrapper = mount(
         <Checkbox value="Duck" onChange={jest.fn()}>

--- a/packages/thumbprint-react/components/Checkbox/test.tsx
+++ b/packages/thumbprint-react/components/Checkbox/test.tsx
@@ -162,7 +162,7 @@ test('adds `dataTest` prop', () => {
     expect(wrapper).toMatchSnapshot();
 });
 
-test('adds `dataTest` prop', () => {
+test('adds `dataTestId` prop', () => {
     const wrapper = mount(
         <Checkbox dataTestId="Duck" onChange={jest.fn()}>
             Goose

--- a/packages/thumbprint-react/components/Dropdown/__snapshots__/test.tsx.snap
+++ b/packages/thumbprint-react/components/Dropdown/__snapshots__/test.tsx.snap
@@ -37,6 +37,43 @@ exports[`adds \`dataTest\` prop 1`] = `
 </Dropdown>
 `;
 
+exports[`adds \`dataTestId\` prop 1`] = `
+<Dropdown
+  dataTestId="Duck"
+  onChange={[Function]}
+  value="goose"
+>
+  <div
+    className="root"
+  >
+    <select
+      className="select selectStateDefault selectSizeLarge"
+      data-testid="Duck"
+      disabled={false}
+      onChange={[Function]}
+      onClick={[Function]}
+      required={false}
+      value="goose"
+    />
+    <svg
+      className="caret"
+      fill="none"
+      height="18"
+      stroke="#2f3033"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="3"
+      viewBox="0 0 24 24"
+      width="18"
+    >
+      <polyline
+        points="6 9 12 15 18 9"
+      />
+    </svg>
+  </div>
+</Dropdown>
+`;
+
 exports[`adds \`disabled\` attribute 1`] = `
 <Dropdown
   isDisabled={true}

--- a/packages/thumbprint-react/components/Dropdown/index.tsx
+++ b/packages/thumbprint-react/components/Dropdown/index.tsx
@@ -85,6 +85,11 @@ interface PropTypes {
     /**
      * A selector hook into the React component for use in automated testing environments.
      */
+    dataTestId?: string;
+    /**
+     * A selector hook into the React component for use in automated testing environments.
+     * @deprecated
+     */
     dataTest?: string;
     /**
      * Adds `name` HTML attribute to element, indicating the property name associated with the
@@ -96,6 +101,7 @@ interface PropTypes {
 const Dropdown = ({
     children,
     dataTest,
+    dataTestId,
     hasError = false,
     id,
     isDisabled = false,
@@ -135,6 +141,7 @@ const Dropdown = ({
                 onChange={(event): void => onChange(event.target.value, event)}
                 onFocus={onFocus}
                 onBlur={onBlur}
+                data-testid={dataTestId}
                 data-test={dataTest}
                 name={name}
             >

--- a/packages/thumbprint-react/components/Dropdown/test.tsx
+++ b/packages/thumbprint-react/components/Dropdown/test.tsx
@@ -99,6 +99,12 @@ test('adds `dataTest` prop', () => {
     expect(wrapperA).toMatchSnapshot();
 });
 
+test('adds `dataTestId` prop', () => {
+    const wrapperA = mount(<Dropdown dataTestId="Duck" onChange={noop} value="goose" />);
+    expect(wrapperA.find('select').prop('data-testid')).toEqual('Duck');
+    expect(wrapperA).toMatchSnapshot();
+});
+
 test('adds `name` HTML attribute', () => {
     const wrapperA = mount(<Dropdown name="duck" onChange={noop} value="goose" />);
     expect(wrapperA.find('select').prop('name')).toEqual('duck');

--- a/packages/thumbprint-react/components/Grid/__snapshots__/test.tsx.snap
+++ b/packages/thumbprint-react/components/Grid/__snapshots__/test.tsx.snap
@@ -23,6 +23,29 @@ exports[`GridColumn adds \`dataTest\` prop 1`] = `
 </Grid>
 `;
 
+exports[`GridColumn adds \`dataTestId\` prop 1`] = `
+<Grid
+  dataTestId="Duck"
+>
+  <div
+    className="grid"
+    data-testid="Duck"
+  >
+    <GridColumn
+      base={1}
+      dataTestId="Goose"
+    >
+      <div
+        className="col col1"
+        data-testid="Goose"
+      >
+        goose
+      </div>
+    </GridColumn>
+  </div>
+</Grid>
+`;
+
 exports[`GridColumn column renders content that is passed in 1`] = `
 <Grid>
   <div

--- a/packages/thumbprint-react/components/Grid/index.tsx
+++ b/packages/thumbprint-react/components/Grid/index.tsx
@@ -37,6 +37,11 @@ interface ColumnPropTypes {
     /**
      * A selector hook into the React component for use in automated testing environments.
      */
+    dataTestId?: string;
+    /**
+     * A selector hook into the React component for use in automated testing environments.
+     * @deprecated
+     */
     dataTest?: string;
 }
 
@@ -46,6 +51,7 @@ export function GridColumn({
     aboveSmall,
     aboveMedium,
     aboveLarge,
+    dataTestId,
     dataTest,
 }: ColumnPropTypes): JSX.Element {
     return (
@@ -64,6 +70,7 @@ export function GridColumn({
                             [styles[`aboveMediumCol${aboveMedium}`]]: aboveMedium,
                             [styles[`aboveLargeCol${aboveLarge}`]]: aboveLarge,
                         })}
+                        data-testid={dataTestId}
                         data-test={dataTest}
                     >
                         {children}
@@ -86,10 +93,20 @@ interface GridPropTypes {
     /**
      * A selector hook into the React component for use in automated testing environments.
      */
+    dataTestId?: string;
+    /**
+     * A selector hook into the React component for use in automated testing environments.
+     * @deprecated
+     */
     dataTest?: string;
 }
 
-export function Grid({ children, gutter = 'normal', dataTest }: GridPropTypes): JSX.Element {
+export function Grid({
+    children,
+    gutter = 'normal',
+    dataTestId,
+    dataTest,
+}: GridPropTypes): JSX.Element {
     return (
         <div
             className={classNames({
@@ -97,6 +114,7 @@ export function Grid({ children, gutter = 'normal', dataTest }: GridPropTypes): 
                 [styles.gridWide]: gutter === 'wide',
                 [styles.gridFlush]: gutter === 'flush',
             })}
+            data-testid={dataTestId}
             data-test={dataTest}
         >
             <Provider value={{ gutter, isWithinGrid: true }}>{children}</Provider>

--- a/packages/thumbprint-react/components/Grid/test.tsx
+++ b/packages/thumbprint-react/components/Grid/test.tsx
@@ -55,4 +55,17 @@ describe('GridColumn', () => {
         expect(wrapper.find('div[data-test="Goose"]')).toHaveLength(1);
         expect(wrapper).toMatchSnapshot();
     });
+
+    test('adds `dataTestId` prop', () => {
+        const wrapper = mount(
+            <Grid dataTestId="Duck">
+                <GridColumn base={1} dataTestId="Goose">
+                    goose
+                </GridColumn>
+            </Grid>,
+        );
+        expect(wrapper.find('div[data-testid="Duck"]')).toHaveLength(1);
+        expect(wrapper.find('div[data-testid="Goose"]')).toHaveLength(1);
+        expect(wrapper).toMatchSnapshot();
+    });
 });

--- a/packages/thumbprint-react/components/Image/get-scroll-parent.test.tsx
+++ b/packages/thumbprint-react/components/Image/get-scroll-parent.test.tsx
@@ -14,14 +14,14 @@ test('defaults to `document.body`', () => {
 test('looks for immediate parent with `overflow: scroll`', () => {
     const wrapper = mount(
         <div>
-            <div style={{ overflow: 'scroll' }} data-test="parent">
-                <div data-test="child">goose</div>
+            <div style={{ overflow: 'scroll' }} data-testid="parent">
+                <div data-testid="child">goose</div>
             </div>
         </div>,
     );
 
-    const child = wrapper.find('[data-test="child"]').getDOMNode();
-    const parent = wrapper.find('[data-test="parent"]').getDOMNode();
+    const child = wrapper.find('[data-testid="child"]').getDOMNode();
+    const parent = wrapper.find('[data-testid="parent"]').getDOMNode();
 
     expect(getScrollParent(child)).toBe(parent);
 });
@@ -29,18 +29,18 @@ test('looks for immediate parent with `overflow: scroll`', () => {
 test('looks for grandparent with `overflow: scroll`', () => {
     const wrapper = mount(
         <div>
-            <div style={{ overflow: 'scroll' }} data-test="parent">
+            <div style={{ overflow: 'scroll' }} data-testid="parent">
                 <div>
                     <div>
-                        <p data-test="child">goose</p>
+                        <p data-testid="child">goose</p>
                     </div>
                 </div>
             </div>
         </div>,
     );
 
-    const child = wrapper.find('[data-test="child"]').getDOMNode();
-    const parent = wrapper.find('[data-test="parent"]').getDOMNode();
+    const child = wrapper.find('[data-testid="child"]').getDOMNode();
+    const parent = wrapper.find('[data-testid="parent"]').getDOMNode();
 
     expect(getScrollParent(child)).toBe(parent);
 });
@@ -48,14 +48,14 @@ test('looks for grandparent with `overflow: scroll`', () => {
 test('looks for parents with `overflow: auto`', () => {
     const wrapper = mount(
         <div>
-            <div style={{ overflow: 'auto' }} data-test="parent">
-                <div data-test="child">goose</div>
+            <div style={{ overflow: 'auto' }} data-testid="parent">
+                <div data-testid="child">goose</div>
             </div>
         </div>,
     );
 
-    const child = wrapper.find('[data-test="child"]').getDOMNode();
-    const parent = wrapper.find('[data-test="parent"]').getDOMNode();
+    const child = wrapper.find('[data-testid="child"]').getDOMNode();
+    const parent = wrapper.find('[data-testid="parent"]').getDOMNode();
 
     expect(getScrollParent(child)).toBe(parent);
 });
@@ -63,14 +63,14 @@ test('looks for parents with `overflow: auto`', () => {
 test('looks for parents with `overflow-y: auto`', () => {
     const wrapper = mount(
         <div>
-            <div style={{ overflowY: 'auto' }} data-test="parent">
-                <div data-test="child">goose</div>
+            <div style={{ overflowY: 'auto' }} data-testid="parent">
+                <div data-testid="child">goose</div>
             </div>
         </div>,
     );
 
-    const child = wrapper.find('[data-test="child"]').getDOMNode();
-    const parent = wrapper.find('[data-test="parent"]').getDOMNode();
+    const child = wrapper.find('[data-testid="child"]').getDOMNode();
+    const parent = wrapper.find('[data-testid="parent"]').getDOMNode();
 
     expect(getScrollParent(child)).toBe(parent);
 });
@@ -78,14 +78,14 @@ test('looks for parents with `overflow-y: auto`', () => {
 test('looks for parents with `overflow-x: auto`', () => {
     const wrapper = mount(
         <div>
-            <div style={{ overflowX: 'auto' }} data-test="parent">
-                <div data-test="child">goose</div>
+            <div style={{ overflowX: 'auto' }} data-testid="parent">
+                <div data-testid="child">goose</div>
             </div>
         </div>,
     );
 
-    const child = wrapper.find('[data-test="child"]').getDOMNode();
-    const parent = wrapper.find('[data-test="parent"]').getDOMNode();
+    const child = wrapper.find('[data-testid="child"]').getDOMNode();
+    const parent = wrapper.find('[data-testid="parent"]').getDOMNode();
 
     expect(getScrollParent(child)).toBe(parent);
 });
@@ -95,15 +95,15 @@ test('finds parent and ignores grandparent nodes', () => {
         <div>
             <div style={{ overflow: 'auto' }}>hi</div>
             <div style={{ overflow: 'auto' }}>
-                <div style={{ overflow: 'auto' }} data-test="parent">
-                    <div data-test="child">goose</div>
+                <div style={{ overflow: 'auto' }} data-testid="parent">
+                    <div data-testid="child">goose</div>
                 </div>
             </div>
         </div>,
     );
 
-    const child = wrapper.find('[data-test="child"]').getDOMNode();
-    const parent = wrapper.find('[data-test="parent"]').getDOMNode();
+    const child = wrapper.find('[data-testid="child"]').getDOMNode();
+    const parent = wrapper.find('[data-testid="parent"]').getDOMNode();
 
     expect(getScrollParent(child)).toBe(parent);
 });

--- a/packages/thumbprint-react/components/Image/test.tsx
+++ b/packages/thumbprint-react/components/Image/test.tsx
@@ -18,11 +18,11 @@ test('forwards props to the outermost element', () => {
     const wrapper = mount(
         <Image
             src="https://d1vg1gqh4nkuns.cloudfront.net/i/356206765797793818/width/1024.jpeg"
-            data-test="goose"
+            data-testid="goose"
         />,
     );
 
-    expect(wrapper.prop('data-test')).toBe('goose');
+    expect(wrapper.prop('data-testid')).toBe('goose');
 });
 
 test('creates one IntersectionObserver instance if there is one scrollable parent', () => {

--- a/packages/thumbprint-react/components/InputRow/__snapshots__/test.tsx.snap
+++ b/packages/thumbprint-react/components/InputRow/__snapshots__/test.tsx.snap
@@ -48,6 +48,54 @@ exports[`adds \`dataTest\` prop 1`] = `
 </InputRow>
 `;
 
+exports[`adds \`dataTestId\` prop 1`] = `
+<InputRow
+  dataTestId="Duck"
+>
+  <div
+    className="root"
+    data-testid="Duck"
+  >
+    <div
+      key=".0"
+      style={
+        Object {
+          "flex": undefined,
+        }
+      }
+    >
+      <button
+        type="button"
+      />
+    </div>
+    <div
+      key=".1"
+      style={
+        Object {
+          "flex": undefined,
+        }
+      }
+    >
+      <button
+        type="button"
+      />
+    </div>
+    <div
+      key=".2"
+      style={
+        Object {
+          "flex": undefined,
+        }
+      }
+    >
+      <button
+        type="button"
+      />
+    </div>
+  </div>
+</InputRow>
+`;
+
 exports[`renders all children 1`] = `
 <InputRow>
   <div

--- a/packages/thumbprint-react/components/InputRow/index.tsx
+++ b/packages/thumbprint-react/components/InputRow/index.tsx
@@ -23,6 +23,11 @@ interface PropTypes {
     /**
      * A selector hook into the React component for use in automated testing environments.
      */
+    dataTestId?: string;
+    /**
+     * A selector hook into the React component for use in automated testing environments.
+     * @deprecated
+     */
     dataTest?: string;
 }
 
@@ -37,7 +42,12 @@ const InputRowContext = React.createContext({
 
 export { InputRowContext };
 
-export default function InputRow({ widthRatios, children, dataTest }: PropTypes): JSX.Element {
+export default function InputRow({
+    widthRatios,
+    children,
+    dataTest,
+    dataTestId,
+}: PropTypes): JSX.Element {
     const widthLength = widthRatios && widthRatios.length;
     const numChildren = React.Children.count(children);
 
@@ -52,7 +62,7 @@ export default function InputRow({ widthRatios, children, dataTest }: PropTypes)
     );
 
     return (
-        <div className={styles.root} data-test={dataTest}>
+        <div className={styles.root} data-test={dataTest} data-testid={dataTestId}>
             {React.Children.map(children, (child, i) => (
                 <div style={{ flex: widthRatios ? `${widthRatios[i]}` : undefined }}>
                     <InputRowContext.Provider

--- a/packages/thumbprint-react/components/InputRow/test.tsx
+++ b/packages/thumbprint-react/components/InputRow/test.tsx
@@ -87,3 +87,15 @@ test('adds `dataTest` prop', () => {
     expect(wrapper.find('div[data-test="Duck"]')).toHaveLength(1);
     expect(wrapper).toMatchSnapshot();
 });
+
+test('adds `dataTestId` prop', () => {
+    const wrapper = mount(
+        <InputRow dataTestId="Duck">
+            <button type="button" />
+            <button type="button" />
+            <button type="button" />
+        </InputRow>,
+    );
+    expect(wrapper.find('div[data-testid="Duck"]')).toHaveLength(1);
+    expect(wrapper).toMatchSnapshot();
+});

--- a/packages/thumbprint-react/components/UIAction/plain.tsx
+++ b/packages/thumbprint-react/components/UIAction/plain.tsx
@@ -24,6 +24,7 @@ const Plain = React.forwardRef<HTMLAnchorElement | HTMLButtonElement, PropTypes>
             onMouseLeave,
             onBlur,
             accessibilityLabel,
+            dataTestId,
             dataTest,
         },
         ref,
@@ -68,6 +69,7 @@ const Plain = React.forwardRef<HTMLAnchorElement | HTMLButtonElement, PropTypes>
                 [styles.plainThemeInherit]: theme === 'inherit',
             }),
             'aria-label': accessibilityLabel,
+            'data-testid': dataTestId,
             'data-test': dataTest,
             ref,
         };
@@ -164,6 +166,11 @@ interface PropTypes {
     accessibilityLabel?: string;
     /**
      * A selector hook into the React component for use in automated testing environments.
+     */
+    dataTestId?: string;
+    /**
+     * A selector hook into the React component for use in automated testing environments.
+     * @deprecated
      */
     dataTest?: string;
 }

--- a/packages/thumbprint-react/components/UIAction/themed.tsx
+++ b/packages/thumbprint-react/components/UIAction/themed.tsx
@@ -103,6 +103,7 @@ const Themed = React.forwardRef<HTMLButtonElement | HTMLAnchorElement, PropTypes
             size = 'large',
             theme = 'primary',
             width = 'auto',
+            dataTestId,
             dataTest,
         }: PropTypes,
         ref,
@@ -158,6 +159,7 @@ const Themed = React.forwardRef<HTMLButtonElement | HTMLAnchorElement, PropTypes
                         disabled: isLoading || isDisabled,
                         className,
                         'aria-label': accessibilityLabel,
+                        'data-testid': dataTestId,
                         'data-test': dataTest,
                     };
 
@@ -303,6 +305,11 @@ interface PropTypes {
     width?: 'auto' | 'full' | 'full-below-small';
     /**
      * A selector hook into the React component for use in automated testing environments.
+     */
+    dataTestId?: string;
+    /**
+     * A selector hook into the React component for use in automated testing environments.
+     * @deprecated
      */
     dataTest?: string;
 }


### PR DESCRIPTION
Relates to #724.

A future CR will remove usage of `dataTest` as a breaking change.