### PR TITLE
Add `dataTestId` to `Link` and `ThemedLink`

### DIFF
--- a/packages/thumbprint-react/CHANGELOG.md
+++ b/packages/thumbprint-react/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+-   [Minor] Add missing `dataTestId` prop to `Link` and `ThemedLink` components. (#724)
+
 ## 14.2.0 - 2020-10-21
 
 ### Added

--- a/packages/thumbprint-react/components/Link/__snapshots__/test.tsx.snap
+++ b/packages/thumbprint-react/components/Link/__snapshots__/test.tsx.snap
@@ -56,6 +56,62 @@ exports[`adds \`dataTest\` prop 2`] = `
 </ForwardRef>
 `;
 
+exports[`adds \`dataTestId\` prop 1`] = `
+<ForwardRef
+  dataTestId="Duck"
+  to="https://example.com/"
+>
+  <ForwardRef
+    dataTestId="Duck"
+    isDisabled={false}
+    shouldOpenInNewTab={false}
+    theme="primary"
+    to="https://example.com/"
+  >
+    <a
+      className="plain plainThemePrimary"
+      data-testid="Duck"
+      disabled={false}
+      href="https://example.com/"
+      target="_self"
+    >
+      Goose
+    </a>
+  </ForwardRef>
+</ForwardRef>
+`;
+
+exports[`adds \`dataTestId\` prop 2`] = `
+<ForwardRef
+  dataTestId="Duck"
+  to="#"
+>
+  <ForwardRef
+    dataTestId="Duck"
+    isDisabled={false}
+    shouldOpenInNewTab={false}
+    size="large"
+    theme="primary"
+    to="#"
+    width="auto"
+  >
+    <a
+      className="themedButton themedButtonRoundedBordersLeft themedButtonRoundedBordersRight themedButtonThemePrimary themedButtonWidthAuto"
+      data-testid="Duck"
+      disabled={false}
+      href="#"
+      target="_self"
+    >
+      <span
+        className="flexWrapper flexWrapperSizeLarge"
+      >
+        Goose
+      </span>
+    </a>
+  </ForwardRef>
+</ForwardRef>
+`;
+
 exports[`adds \`rel\` attribute to handle security vulnerability for \`shouldOpenInNewTab\` 1`] = `
 <ForwardRef
   shouldOpenInNewTab={true}

--- a/packages/thumbprint-react/components/Link/index.tsx
+++ b/packages/thumbprint-react/components/Link/index.tsx
@@ -9,6 +9,7 @@ interface CommonProps {
     children?: React.ReactNode;
     isDisabled?: boolean;
     onClick?: () => void;
+    dataTestId?: string;
     dataTest?: string;
     accessibilityLabel?: string;
 }
@@ -28,6 +29,7 @@ const getCommonLinkProps = (props: CommonProps): CommonProps => {
         isDisabled: props.isDisabled,
         children: props.children,
         accessibilityLabel: props.accessibilityLabel,
+        dataTestId: props.dataTestId,
         dataTest: props.dataTest,
     };
 };
@@ -46,6 +48,7 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkPropTypes>(
             children,
             accessibilityLabel,
             dataTest,
+            dataTestId,
             theme = 'primary',
             iconLeft,
             iconRight,
@@ -62,6 +65,7 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkPropTypes>(
                 children,
                 accessibilityLabel,
                 dataTest,
+                dataTestId,
             })}
             theme={theme}
             iconLeft={iconLeft}
@@ -122,6 +126,11 @@ interface LinkPropTypes {
     /**
      * A selector hook into the React component for use in automated testing environments.
      */
+    dataTestId?: string;
+    /**
+     * A selector hook into the React component for use in automated testing environments.
+     * @deprecated Deprecated in favor of the `dataTestId` prop
+     */
     dataTest?: string;
 }
 
@@ -139,6 +148,7 @@ const ThemedLink = React.forwardRef<HTMLAnchorElement, ThemedLinkPropTypes>(
             children,
             accessibilityLabel,
             dataTest,
+            dataTestId,
             icon,
             iconRight,
             theme = 'primary',
@@ -157,6 +167,7 @@ const ThemedLink = React.forwardRef<HTMLAnchorElement, ThemedLinkPropTypes>(
                 children,
                 accessibilityLabel,
                 dataTest,
+                dataTestId,
             })}
             icon={icon}
             iconRight={iconRight}
@@ -225,6 +236,11 @@ interface ThemedLinkPropTypes {
     width?: 'auto' | 'full' | 'full-below-small';
     /**
      * A selector hook into the React component for use in automated testing environments.
+     */
+    dataTestId?: string;
+    /**
+     * A selector hook into the React component for use in automated testing environments.
+     * @deprecated Deprecated in favor of the `dataTestId` prop
      */
     dataTest?: string;
 }

--- a/packages/thumbprint-react/components/Link/test.tsx
+++ b/packages/thumbprint-react/components/Link/test.tsx
@@ -175,3 +175,21 @@ test('adds `dataTest` prop', () => {
     expect(wrapperB.find('a').prop('data-test')).toEqual('Duck');
     expect(wrapperB).toMatchSnapshot();
 });
+
+test('adds `dataTestId` prop', () => {
+    const wrapperA = mount(
+        <Link to="https://example.com/" dataTestId="Duck">
+            Goose
+        </Link>,
+    );
+    expect(wrapperA.find('a').prop('data-testid')).toEqual('Duck');
+    expect(wrapperA).toMatchSnapshot();
+
+    const wrapperB = mount(
+        <ThemedLink to="#" dataTestId="Duck">
+            Goose
+        </ThemedLink>,
+    );
+    expect(wrapperB.find('a').prop('data-testid')).toEqual('Duck');
+    expect(wrapperB).toMatchSnapshot();
+});


### PR DESCRIPTION
This should have happened in a previous PR but I missed this component.