### PR TITLE
Add dataTest deprecation message in PropTypes documentation.

### DIFF
--- a/packages/thumbprint-react/CHANGELOG.md
+++ b/packages/thumbprint-react/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+-   [Patch] Add note in `dataTest` deprecated documentation telling developers to use `dataTestId` instead.
+
 ## 14.2.0 - 2020-10-21
 
 ### Added

--- a/packages/thumbprint-react/components/Alert/index.tsx
+++ b/packages/thumbprint-react/components/Alert/index.tsx
@@ -19,7 +19,7 @@ interface BannerPropTypes {
     dataTestId?: string;
     /**
      * A selector to hook into the React component for use in automated testing environments.
-     * @deprecated
+     * @deprecated Deprecated in favor of the `dataTestId` prop
      */
     dataTest?: string;
 }
@@ -63,7 +63,7 @@ interface InPagePropTypes {
     dataTestId?: string;
     /**
      * A selector to hook into the React component for use in automated testing environments.
-     * @deprecated
+     * @deprecated Deprecated in favor of the `dataTestId` prop
      */
     dataTest?: string;
 }

--- a/packages/thumbprint-react/components/AlertBanner/index.tsx
+++ b/packages/thumbprint-react/components/AlertBanner/index.tsx
@@ -18,7 +18,7 @@ interface AlertBannerPropTypes {
     dataTestId?: string;
     /**
      * A selector to hook into the React component for use in automated testing environments.
-     * @deprecated
+     * @deprecated Deprecated in favor of the `dataTestId` prop
      */
     dataTest?: string;
 }

--- a/packages/thumbprint-react/components/Button/index.tsx
+++ b/packages/thumbprint-react/components/Button/index.tsx
@@ -142,7 +142,7 @@ interface TextButtonPropTypes {
     dataTestId?: string;
     /**
      * A selector hook into the React component for use in automated testing environments.
-     * @deprecated
+     * @deprecated Deprecated in favor of the `dataTestId` prop
      */
     dataTest?: string;
 }
@@ -275,7 +275,7 @@ interface ButtonPropTypes {
     dataTestId?: string;
     /**
      * A selector hook into the React component for use in automated testing environments.
-     * @deprecated
+     * @deprecated Deprecated in favor of the `dataTestId` prop
      */
     dataTest?: string;
 }

--- a/packages/thumbprint-react/components/ButtonRow/index.tsx
+++ b/packages/thumbprint-react/components/ButtonRow/index.tsx
@@ -22,7 +22,7 @@ interface PropTypes {
     dataTestId?: string;
     /**
      * A selector hook into the React component for use in automated testing environments.
-     * @deprecated
+     * @deprecated Deprecated in favor of the `dataTestId` prop
      */
     dataTest?: string;
 }

--- a/packages/thumbprint-react/components/Checkbox/index.tsx
+++ b/packages/thumbprint-react/components/Checkbox/index.tsx
@@ -158,7 +158,7 @@ interface PropTypes {
     /**
      * A selector hook into the React component for use in automated testing environments. It is
      * applied internally to the `<input />` element.
-     * @deprecated
+     * @deprecated Deprecated in favor of the `dataTestId` prop
      */
     dataTest?: string;
     /**

--- a/packages/thumbprint-react/components/Dropdown/index.tsx
+++ b/packages/thumbprint-react/components/Dropdown/index.tsx
@@ -88,7 +88,7 @@ interface PropTypes {
     dataTestId?: string;
     /**
      * A selector hook into the React component for use in automated testing environments.
-     * @deprecated
+     * @deprecated Deprecated in favor of the `dataTestId` prop
      */
     dataTest?: string;
     /**

--- a/packages/thumbprint-react/components/Grid/index.tsx
+++ b/packages/thumbprint-react/components/Grid/index.tsx
@@ -40,7 +40,7 @@ interface ColumnPropTypes {
     dataTestId?: string;
     /**
      * A selector hook into the React component for use in automated testing environments.
-     * @deprecated
+     * @deprecated Deprecated in favor of the `dataTestId` prop
      */
     dataTest?: string;
 }
@@ -96,7 +96,7 @@ interface GridPropTypes {
     dataTestId?: string;
     /**
      * A selector hook into the React component for use in automated testing environments.
-     * @deprecated
+     * @deprecated Deprecated in favor of the `dataTestId` prop
      */
     dataTest?: string;
 }

--- a/packages/thumbprint-react/components/InputRow/index.tsx
+++ b/packages/thumbprint-react/components/InputRow/index.tsx
@@ -26,7 +26,7 @@ interface PropTypes {
     dataTestId?: string;
     /**
      * A selector hook into the React component for use in automated testing environments.
-     * @deprecated
+     * @deprecated Deprecated in favor of the `dataTestId` prop
      */
     dataTest?: string;
 }

--- a/packages/thumbprint-react/components/UIAction/plain.tsx
+++ b/packages/thumbprint-react/components/UIAction/plain.tsx
@@ -170,7 +170,7 @@ interface PropTypes {
     dataTestId?: string;
     /**
      * A selector hook into the React component for use in automated testing environments.
-     * @deprecated
+     * @deprecated Deprecated in favor of the `dataTestId` prop
      */
     dataTest?: string;
 }

--- a/packages/thumbprint-react/components/UIAction/themed.tsx
+++ b/packages/thumbprint-react/components/UIAction/themed.tsx
@@ -309,7 +309,7 @@ interface PropTypes {
     dataTestId?: string;
     /**
      * A selector hook into the React component for use in automated testing environments.
-     * @deprecated
+     * @deprecated Deprecated in favor of the `dataTestId` prop
      */
     dataTest?: string;
 }


### PR DESCRIPTION
This will let developers know what the replacement is.