### PR TITLE
Remove unnecessary canUseDOM check from Popover.

### DIFF
--- a/packages/thumbprint-react/CHANGELOG.md
+++ b/packages/thumbprint-react/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+-   [Patch] Fix server-side rendering Popover bug.
+
 ## 14.3.3 - 2020-11-19
 
 ### Fixed

--- a/packages/thumbprint-react/components/Popover/index.tsx
+++ b/packages/thumbprint-react/components/Popover/index.tsx
@@ -89,74 +89,72 @@ export default function Popover({
         <Manager>
             <Reference>{({ ref }): React.ReactNode => launcher({ ref })}</Reference>
             <ConditionalPortal shouldDisplace={shouldDisplace}>
-                {canUseDOM && (
-                    <Popper
-                        placement={position}
-                        modifiers={{
-                            offset: { offset: `0, ${tokens.tpSpace3}` },
-                            preventOverflow: { boundariesElement: 'window' },
-                        }}
-                        positionFixed={false}
-                    >
-                        {({ ref: popperRef, style, placement, arrowProps }): JSX.Element => (
-                            // Use tabIndex={-1} to allow programmatic focus (as initialFocus node
-                            // for focus-trap) but not be tabbable by user.
-                            <div
-                                role="dialog"
-                                aria-label={accessibilityLabel}
-                                tabIndex={-1}
-                                ref={(el: HTMLDivElement | null): void => {
-                                    setWrapperEl(el);
-                                    popperRef(el);
-                                }}
-                                className={classNames({
-                                    [styles.root]: true,
-                                    [styles.open]: isOpen,
-                                })}
-                                style={style}
-                                data-placement={placement}
-                            >
-                                {children}
+                <Popper
+                    placement={position}
+                    modifiers={{
+                        offset: { offset: `0, ${tokens.tpSpace3}` },
+                        preventOverflow: { boundariesElement: 'window' },
+                    }}
+                    positionFixed={false}
+                >
+                    {({ ref: popperRef, style, placement, arrowProps }): JSX.Element => (
+                        // Use tabIndex={-1} to allow programmatic focus (as initialFocus node
+                        // for focus-trap) but not be tabbable by user.
+                        <div
+                            role="dialog"
+                            aria-label={accessibilityLabel}
+                            tabIndex={-1}
+                            ref={(el: HTMLDivElement | null): void => {
+                                setWrapperEl(el);
+                                popperRef(el);
+                            }}
+                            className={classNames({
+                                [styles.root]: true,
+                                [styles.open]: isOpen,
+                            })}
+                            style={style}
+                            data-placement={placement}
+                        >
+                            {children}
 
-                                <div className={styles.closeButton}>
-                                    <TextButton
-                                        accessibilityLabel="Close popover"
-                                        iconLeft={
-                                            <svg
-                                                viewBox="0 0 24 24"
-                                                width="14"
-                                                height="14"
-                                                stroke="currentColor"
-                                                strokeWidth="3"
-                                                fill="none"
-                                                strokeLinecap="round"
-                                                strokeLinejoin="round"
-                                                className={styles.closeButtonIcon}
-                                            >
-                                                <line x1="18" y1="6" x2="6" y2="18" />
-                                                <line x1="6" y1="6" x2="18" y2="18" />
-                                            </svg>
-                                        }
-                                        theme="inherit"
-                                        onClick={onCloseClick}
-                                    />
-                                </div>
-
-                                <div
-                                    className={classNames({
-                                        [styles.nubbin]: true,
-                                        [styles.nubbinTop]: startsWith(placement, 'bottom'),
-                                        [styles.nubbinBottom]: startsWith(placement, 'top'),
-                                        [styles.nubbinLeft]: startsWith(placement, 'right'),
-                                        [styles.nubbinRight]: startsWith(placement, 'left'),
-                                    })}
-                                    ref={arrowProps.ref}
-                                    style={arrowProps.style}
+                            <div className={styles.closeButton}>
+                                <TextButton
+                                    accessibilityLabel="Close popover"
+                                    iconLeft={
+                                        <svg
+                                            viewBox="0 0 24 24"
+                                            width="14"
+                                            height="14"
+                                            stroke="currentColor"
+                                            strokeWidth="3"
+                                            fill="none"
+                                            strokeLinecap="round"
+                                            strokeLinejoin="round"
+                                            className={styles.closeButtonIcon}
+                                        >
+                                            <line x1="18" y1="6" x2="6" y2="18" />
+                                            <line x1="6" y1="6" x2="18" y2="18" />
+                                        </svg>
+                                    }
+                                    theme="inherit"
+                                    onClick={onCloseClick}
                                 />
                             </div>
-                        )}
-                    </Popper>
-                )}
+
+                            <div
+                                className={classNames({
+                                    [styles.nubbin]: true,
+                                    [styles.nubbinTop]: startsWith(placement, 'bottom'),
+                                    [styles.nubbinBottom]: startsWith(placement, 'top'),
+                                    [styles.nubbinLeft]: startsWith(placement, 'right'),
+                                    [styles.nubbinRight]: startsWith(placement, 'left'),
+                                })}
+                                ref={arrowProps.ref}
+                                style={arrowProps.style}
+                            />
+                        </div>
+                    )}
+                </Popper>
             </ConditionalPortal>
         </Manager>
     );


### PR DESCRIPTION
This was causing issues in on RR pages described in:

https://thumbtack.slack.com/archives/C0GKYQVTR/p1616022352008000

(Link is internal only.)

After creating a small reproduction, I realized that removing `canUseDOM` fixes the problem. I'm not 100% sure why, but I imagine it is related to React's client-side hydration. `canUseDOM` is always false on the server but defaults to `true` on the client. I imagine this isn't an issue with components like Tooltip because they default to being closed and require user interaction to appear.