### PR TITLE
Add UNSAFE prefix to deprecated React lifecycle methods.

### DIFF
--- a/packages/thumbprint-react/CHANGELOG.md
+++ b/packages/thumbprint-react/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+-   [Patch] Add UNSAFE prefix to deprecated React lifecycle methods, prepping for React 17 support.
+
 ## 14.3.4 - 2021-03-23
 
 ### Fixed

--- a/packages/thumbprint-react/components/ModalBase/subcomponents/modal-structure/index.jsx
+++ b/packages/thumbprint-react/components/ModalBase/subcomponents/modal-structure/index.jsx
@@ -48,7 +48,12 @@ export default class ModalStructure extends React.Component {
         }
     }
 
-    componentWillUpdate(nextProps) {
+    componentWillUnmount() {
+        this.toggleKeyDownListener(false, false);
+        toggleScrolling(false);
+    }
+
+    UNSAFE_componentWillUpdate(nextProps) {
         const { isOpen, onOpenFinish, onCloseFinish, shouldCloseOnEscape } = this.props;
 
         // Enable or disable the background scrolling if the `isOpen` prop has changed.
@@ -68,11 +73,6 @@ export default class ModalStructure extends React.Component {
         if (isOpen !== nextProps.isOpen || shouldCloseOnEscape !== nextProps.shouldCloseOnEscape) {
             this.toggleKeyDownListener(nextProps.isOpen, nextProps.shouldCloseOnEscape);
         }
-    }
-
-    componentWillUnmount() {
-        this.toggleKeyDownListener(false, false);
-        toggleScrolling(false);
     }
 
     handleKeyDown(event) {


### PR DESCRIPTION
This is needed for the codebase to work with React 17.