### PR TITLE
Recommend using import with tilde in docs.

### DIFF
--- a/www/src/pages/components/global-css/scss/index.mdx
+++ b/www/src/pages/components/global-css/scss/index.mdx
@@ -21,7 +21,7 @@ yarn add @thumbtack/thumbprint-global-css
 ## SCSS usage
 
 ```scss
-@import '[node_modules path]/@thumbtack/thumbprint-global-css/dist/thumbprint-global';
+@import '~@thumbtack/thumbprint-global-css/dist/thumbprint-global';
 ```
 
 ## JavaScript usage

--- a/www/src/pages/components/mixins/scss/index.mdx
+++ b/www/src/pages/components/mixins/scss/index.mdx
@@ -23,7 +23,7 @@ Helpful SCSS mixins for using media queries and setting breakpoints. These mixin
 
 ```scss
 // Include this `import` at the top of your file.
-@import '@thumbtack/thumbprint-scss/mixins';
+@import '~@thumbtack/thumbprint-scss/mixins';
 
 @include tp-respond-between($tp-breakpoint__small, $tp-breakpoint__medium) {
     // The CSS within this block will render between the specified breakpoints.
@@ -34,7 +34,7 @@ Helpful SCSS mixins for using media queries and setting breakpoints. These mixin
 
 ```scss
 // Include this `import` at the top of your file.
-@import '@thumbtack/thumbprint-scss/mixins';
+@import '~@thumbtack/thumbprint-scss/mixins';
 
 @include tp-respond-above($tp-breakpoint__small) {
     // The CSS within this block will render above specified breakpoint.
@@ -45,7 +45,7 @@ Helpful SCSS mixins for using media queries and setting breakpoints. These mixin
 
 ```scss
 // Include this `import` at the top of your file.
-@import '@thumbtack/thumbprint-scss/mixins';
+@import '~@thumbtack/thumbprint-scss/mixins';
 
 @include tp-respond-below($tp-breakpoint__large) {
     // The CSS within this block will render below the specified breakpoint.

--- a/www/src/pages/tokens/scss/index.mdx
+++ b/www/src/pages/tokens/scss/index.mdx
@@ -42,7 +42,7 @@ export const pageQuery = graphql`
     packageName="@thumbtack/thumbprint-tokens"
     sourceDirectory="https://github.com/thumbtack/thumbprint-tokens"
     platform="web"
-    importStatement={`@import "@thumbtack/thumbprint-tokens/dist/scss/_index";`}
+    importStatement={`@import '~@thumbtack/thumbprint-tokens/dist/scss/_index';`}
 />
 
 <div>


### PR DESCRIPTION
This tells sass-loader to let Wepack find the package, meaning that no changes to Sass's `includePaths` is needed.

This aligns with the pattern we're adopting in the main Thumbtack codebase, making it easier to use tooling like Yarn workspaces where the node_modules may be at the repo root.