### PR TITLE
Add FilterChip to Thumbprint Web Documentation

### DIFF
--- a/packages/thumbprint-react/CHANGELOG.md
+++ b/packages/thumbprint-react/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+-   [Minor] Add documentation for FilterChip component.
+
 ## 14.3.6 - 2021-06-24
 
 ### Changed

--- a/packages/thumbprint-react/components/Chip/__snapshots__/test.tsx.snap
+++ b/packages/thumbprint-react/components/Chip/__snapshots__/test.tsx.snap
@@ -1,0 +1,71 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders \`text\` passed in 1`] = `
+<body>
+  <div>
+    <button
+      aria-pressed="false"
+      class="filterChip br-pill mr1 truncate no-underlin mb1 ph3 pv2 b filterChipNotSelected"
+      type="button"
+    >
+      Beverages
+    </button>
+  </div>
+</body>
+`;
+
+exports[`renders a proper onClick callback 1`] = `
+<body>
+  <div>
+    <button
+      aria-pressed="false"
+      class="filterChip br-pill mr1 truncate no-underlin mb1 ph3 pv2 b filterChipNotSelected"
+      type="button"
+    >
+      Beverages
+    </button>
+  </div>
+</body>
+`;
+
+exports[`renders the correct selected state when clicked 1`] = `
+<body>
+  <div>
+    <button
+      aria-pressed="true"
+      class="filterChip br-pill mr1 truncate no-underlin mb1 ph3 pv2 b filterChipSelected"
+      type="button"
+    >
+      Beverages
+    </button>
+  </div>
+</body>
+`;
+
+exports[`renders the selected state 1`] = `
+<body>
+  <div>
+    <button
+      aria-pressed="true"
+      class="filterChip br-pill mr1 truncate no-underlin mb1 ph3 pv2 b filterChipSelected"
+      type="button"
+    >
+      Beverages
+    </button>
+  </div>
+</body>
+`;
+
+exports[`renders the unselected state by default 1`] = `
+<body>
+  <div>
+    <button
+      aria-pressed="false"
+      class="filterChip br-pill mr1 truncate no-underlin mb1 ph3 pv2 b filterChipNotSelected"
+      type="button"
+    >
+      Beverages
+    </button>
+  </div>
+</body>
+`;

--- a/packages/thumbprint-react/components/Chip/index.module.scss
+++ b/packages/thumbprint-react/components/Chip/index.module.scss
@@ -1,0 +1,17 @@
+@import '~@thumbtack/thumbprint-tokens/dist/scss/_index';
+
+.filterChip {
+    flex: 0 0 auto;
+    font-size: $tp-font__body__3__size;
+    line-height: 18px;
+    &Selected {
+        border: 1px $tp-color__blue-100;
+        color: $tp-color__blue;
+        background-color: $tp-color__blue-100;
+    }
+    &NotSelected {
+        border: 2px solid $tp-color__gray;
+        color: $tp-color__blue;
+        background-color: $tp-color__white;
+    }
+}

--- a/packages/thumbprint-react/components/Chip/index.tsx
+++ b/packages/thumbprint-react/components/Chip/index.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import classNames from 'classnames';
+import styles from './index.module.scss';
+
+interface FilterChipProps {
+    /**
+     * The text to display inside the FilterChip.
+     */
+    text: string;
+    /**
+     * Determines if the FilterChip is selected, which changes the color.
+     * The default is for the FilterChip to start in the unselected state.
+     */
+    isSelected?: boolean;
+    /**
+     * A function to be called whenever the selected state of the chip changes.
+     */
+    onClick: () => void;
+}
+
+export default function FilterChip({
+    text,
+    isSelected = false,
+    onClick,
+}: FilterChipProps): JSX.Element {
+    return (
+        <button
+            className={classNames(
+                styles.filterChip,
+                'br-pill mr1 truncate no-underlin mb1 ph3 pv2 b',
+                isSelected ? styles.filterChipSelected : styles.filterChipNotSelected,
+            )}
+            type="button"
+            onClick={onClick}
+            aria-pressed={isSelected}
+        >
+            {text}
+        </button>
+    );
+}

--- a/packages/thumbprint-react/components/Chip/test.tsx
+++ b/packages/thumbprint-react/components/Chip/test.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { render, fireEvent, screen } from '@testing-library/react';
+import FilterChip from './index';
+
+test('renders `text` passed in', () => {
+    const wrapper = render(<FilterChip text="Beverages" onClick={jest.fn()} />);
+    expect(screen.getByRole('button')).toHaveTextContent('Beverages');
+    expect(wrapper.baseElement).toMatchSnapshot();
+});
+
+test('renders the unselected state by default', () => {
+    const wrapper = render(<FilterChip text="Beverages" onClick={jest.fn()} />);
+    expect(screen.getByRole('button', { pressed: false })).toBeTruthy();
+    expect(wrapper.baseElement).toMatchSnapshot();
+});
+
+test('renders the selected state', () => {
+    const wrapper = render(<FilterChip text="Beverages" isSelected onClick={jest.fn()} />);
+    expect(screen.getByRole('button', { pressed: true })).toBeTruthy();
+    expect(wrapper.baseElement).toMatchSnapshot();
+});
+
+test('renders a proper onClick callback', () => {
+    let count = 0;
+    const onClick = (): void => {
+        count += 1;
+    };
+    const wrapper = render(<FilterChip text="Beverages" onClick={onClick} />);
+    fireEvent.click(screen.getByRole('button'));
+    expect(count).toEqual(1);
+    expect(wrapper.baseElement).toMatchSnapshot();
+});
+
+type ExamplePropTypes = {
+    text: string;
+};
+
+function ExamplePage({ text }: ExamplePropTypes): JSX.Element {
+    const [isSelected, setIsSelected] = React.useState(false);
+    const onClick = (): void => {
+        setIsSelected(!isSelected);
+    };
+    return <FilterChip text={text} onClick={onClick} isSelected={isSelected} />;
+}
+
+test('renders the correct selected state when clicked', () => {
+    const wrapper = render(<ExamplePage text="Beverages" />);
+    expect(screen.getByRole('button', { pressed: false })).toBeTruthy();
+    fireEvent.click(screen.getByRole('button'));
+    const button = screen.getByRole('button', { pressed: true });
+    expect(button).toBeTruthy();
+    expect(button).toHaveTextContent('Beverages');
+    expect(wrapper.baseElement).toMatchSnapshot();
+});
+
+test('renders the correct text when clicked', () => {
+    let isSelected = false;
+    const onClick = (): void => {
+        isSelected = !isSelected;
+    };
+    const { rerender } = render(
+        <FilterChip
+            text={isSelected ? 'Remove Beverages' : 'Include Beverages'}
+            onClick={onClick}
+            isSelected={isSelected}
+        />,
+    );
+    let button = screen.getByRole('button', { pressed: false });
+    expect(button).toBeTruthy();
+    expect(button).toHaveTextContent('Include Beverages');
+    fireEvent.click(screen.getByRole('button'));
+    rerender(
+        <FilterChip
+            text={isSelected ? 'Remove Beverages' : 'Include Beverages'}
+            onClick={onClick}
+            isSelected={isSelected}
+        />,
+    );
+    button = screen.getByRole('button', { pressed: true });
+    expect(button).toBeTruthy();
+    expect(button).toHaveTextContent('Remove Beverages');
+});

--- a/packages/thumbprint-react/index.ts
+++ b/packages/thumbprint-react/index.ts
@@ -55,3 +55,4 @@ export {
 export { default as Tooltip } from './components/Tooltip/index';
 export { Title, Text } from './components/Type/index';
 export { default as Wrap } from './components/Wrap/index';
+export { default as FilterChip } from './components/Chip/index';

--- a/www/src/pages/components/chip/react/index.mdx
+++ b/www/src/pages/components/chip/react/index.mdx
@@ -18,7 +18,7 @@ There are two types of chip components: ToggleChip and FilterChip.
 
 #### ToggleChip
 
-A toggle chip behaves the same way as a checkbox and should be used for a set of options where more than one option can be selected. It is currently not available on React.
+A toggle chip behaves the same way as a checkbox and should be used for a set of options where more than one option can be selected. It is currently not available as a React component.
 
 #### FilterChip
 

--- a/www/src/pages/components/chip/react/index.mdx
+++ b/www/src/pages/components/chip/react/index.mdx
@@ -66,7 +66,6 @@ function MultipleFilterChipExample() {
 }
 ```
 
-
 <ComponentFooter data={props.data} />
 
 export const pageQuery = graphql`

--- a/www/src/pages/components/chip/react/index.mdx
+++ b/www/src/pages/components/chip/react/index.mdx
@@ -1,0 +1,94 @@
+---
+title: Chip
+description: Compact controls that allow for toggling and filtering
+---
+
+import { graphql } from 'gatsby';
+import { ComponentHeader, ComponentFooter } from 'components/thumbprint-components';
+
+<ComponentHeader data={props.data} />
+
+### Usage
+
+Chips allow users to make selections, filter content, or trigger small actions. Chips should appear as a group of multiple elements in most cases. Unlike buttons, chips shouldn’t navigate away from the current page. If the action requires a new page to load, please use a button instead of a chip.
+
+### Components
+
+There are two types of chip components: ToggleChip and FilterChip.
+
+#### ToggleChip
+
+A toggle chip behaves the same way as a checkbox and should be used for a set of options where more than one option can be selected. It is currently not available on React.
+
+#### FilterChip
+
+A filter chip is meant to behave more like a button and should be used for filtering options.
+
+The `isSelected` prop determines if a FilterChip is selected.
+
+```jsx
+function FilterChipExample() {
+    const [isSelected, setIsSelected] = React.useState(undefined);
+    return (
+        <FilterChip
+            text={isSelected ? "I'm Selected" : 'Select Me'}
+            isSelected={isSelected}
+            onClick={() => setIsSelected(!isSelected)}
+        />
+    );
+}
+```
+
+Below is an example of multiple FilterChips.
+
+```jsx
+function MultipleFilterChipExample() {
+    const [selection, setSelection] = React.useState('Canada');
+    return (
+        <div>
+            <FilterChip
+                text="Canada"
+                isSelected={selection == 'Canada'}
+                onClick={() => setSelection('Canada')}
+            />
+            <FilterChip
+                text="United States"
+                isSelected={selection == 'United States'}
+                onClick={() => setSelection('United States')}
+            />
+            <FilterChip
+                text="Philippines"
+                isSelected={selection == 'Philippines'}
+                onClick={() => setSelection('Philippines')}
+            />
+        </div>
+    );
+}
+```
+
+Both types of chips behave the same way to user interaction, they only differ visually and on intended use.
+
+<ComponentFooter data={props.data} />
+
+export const pageQuery = graphql`
+    {
+        # Get links to by path to display in the navbar.
+        platformNav: allSitePage(filter: { path: { glob: "/components/chip/*/" } }) {
+            edges {
+                node {
+                    ...PlatformNavFragment
+                }
+            }
+        }
+        # Get package information by NPM package name.
+        packageTable: thumbprintComponent(name: { eq: "@thumbtack/thumbprint-react" }) {
+            ...PackageTableFragment
+        }
+        # Get component props by path to component file.
+        reactComponentProps: allFile(
+            filter: { relativePath: { in: ["thumbprint-react/components/Chip/index.tsx"] } }
+        ) {
+            ...ReactComponentPropsFragment
+        }
+    }
+`;

--- a/www/src/pages/components/chip/react/index.mdx
+++ b/www/src/pages/components/chip/react/index.mdx
@@ -66,7 +66,6 @@ function MultipleFilterChipExample() {
 }
 ```
 
-Both types of chips behave the same way to user interaction, they only differ visually and on intended use.
 
 <ComponentFooter data={props.data} />
 

--- a/www/src/pages/components/chip/react/index.mdx
+++ b/www/src/pages/components/chip/react/index.mdx
@@ -22,7 +22,7 @@ A toggle chip behaves the same way as a checkbox and should be used for a set of
 
 #### FilterChip
 
-A filter chip is meant to behave more like a button and should be used for filtering options.
+A FilterChip is used to filter options and behaves like a button.
 
 The `isSelected` prop determines if a FilterChip is selected.
 


### PR DESCRIPTION
Hello, this is the addition of the FilterChip to Thumbprint React. There is now a `React` tab for the `Chip` section of the documentation. The tests for the FilterChip were written with RTL. 