### PR TITLE
Remove division to make compatible with dart-sass and node-sass

### DIFF
--- a/packages/thumbprint-react/CHANGELOG.md
+++ b/packages/thumbprint-react/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Changed
+
+-   [Patch] Replace division with multiplation for better Dart Sass support.
+
 ### Added
 
 ## 14.4.0 - 2021-08-16

--- a/packages/thumbprint-react/components/Calendar/index.module.scss
+++ b/packages/thumbprint-react/components/Calendar/index.module.scss
@@ -99,7 +99,7 @@
 
     // IE11 does not seem to recognize the cell dimensions for absolutely positioning the dot
     // without the padding to fill the vertical space.
-    $vertical-padding: ($cell-side - $line-height) / 2 - $border-size;
+    $vertical-padding: ($cell-side - $line-height) * 0.5 - $border-size;
 
     display: table-cell;
     color: $tp-color__black;


### PR DESCRIPTION
The Thumbtack website codebase needs to use dart-sass instead of
node-sass to support the migration to Next.js and have reloads
work with Docker. This change fixes a warning and removes the
deprecated division sign.