### PR TITLE
Bump readme node version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ Use the following commands to run the Thumbprint documentation:
 ```bash
 git clone git@github.com:thumbtack/thumbprint.git
 cd thumbprint
-node -v # This must be 8.x
+node -v # This must be 12.x
 yarn -v # This must be >= 1.4.2
 yarn
 yarn start


### PR DESCRIPTION
Minor change - noticed this error message on setup and wanted to update the readme with the correct node version (as of now):
```
[1/5] 🔍  Validating package.json...
error @: The engine "node" is incompatible with this module. Expected version "12.x". Got "8.9.4"
error Found incompatible module.
```