### PR TITLE
Support additional `rel` values on `Link` and `ThemedLink`

### DIFF
--- a/packages/thumbprint-react/CHANGELOG.md
+++ b/packages/thumbprint-react/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+## 14.4.2 - 2022-02-16
+
+### Changed
+
+-   [Patch] Refactor how default `rel` attribute values are defined
+
+### Added
+
+-   [Minor] Add optional `rel` prop to `Link` and `ThemedLink` components.
+
 ## 14.4.1 - 2021-09-03
 
 ### Changed

--- a/packages/thumbprint-react/components/Link/__snapshots__/test.tsx.snap
+++ b/packages/thumbprint-react/components/Link/__snapshots__/test.tsx.snap
@@ -222,6 +222,66 @@ exports[`adds \`rel\` attribute to handle security vulnerability for \`target=_b
 </ForwardRef>
 `;
 
+exports[`adds \`rel\` attribute when explicitly defined 1`] = `
+<ForwardRef
+  rel="nofollow"
+  target="_blank"
+  to="https://example.com/"
+>
+  <ForwardRef
+    isDisabled={false}
+    rel="nofollow"
+    shouldOpenInNewTab={false}
+    target="_blank"
+    theme="primary"
+    to="https://example.com/"
+  >
+    <a
+      className="plain plainThemePrimary"
+      disabled={false}
+      href="https://example.com/"
+      rel="nofollow noopener noreferrer"
+      target="_blank"
+    >
+      Goose
+    </a>
+  </ForwardRef>
+</ForwardRef>
+`;
+
+exports[`adds \`rel\` attribute when explicitly defined 2`] = `
+<ForwardRef
+  rel="nofollow"
+  target="_blank"
+  to="https://example.com/"
+>
+  <ForwardRef
+    isDisabled={false}
+    rel="nofollow"
+    shouldOpenInNewTab={false}
+    size="large"
+    target="_blank"
+    theme="primary"
+    to="https://example.com/"
+    width="auto"
+  >
+    <a
+      className="themedButton themedButtonRoundedBordersLeft themedButtonRoundedBordersRight themedButtonThemePrimary themedButtonWidthAuto"
+      disabled={false}
+      href="https://example.com/"
+      rel="nofollow noopener noreferrer"
+      target="_blank"
+    >
+      <span
+        className="flexWrapper flexWrapperSizeLarge"
+      >
+        Goose
+      </span>
+    </a>
+  </ForwardRef>
+</ForwardRef>
+`;
+
 exports[`adds attribute to open link in new tab 1`] = `
 <ForwardRef
   shouldOpenInNewTab={true}

--- a/packages/thumbprint-react/components/Link/index.tsx
+++ b/packages/thumbprint-react/components/Link/index.tsx
@@ -104,8 +104,8 @@ interface LinkPropTypes {
      */
     onClick?: () => void;
     /**
-     * The anchor `rel` attribute. Setting this value will override any default value provided by
-     * thumbprint for the `rel` attribute.
+     * The anchor `rel` attribute. Setting this value will add to any default values provided by
+     * Thumbprint for the `rel` attribute.
      */
     rel?: string;
     /**
@@ -213,8 +213,8 @@ interface ThemedLinkPropTypes {
      */
     onClick?: () => void;
     /**
-     * The anchor `rel` attribute. Setting this value will override any default value provided by
-     * thumbprint for the `rel` attribute.
+     * The anchor `rel` attribute. Setting this value will add to any default values provided by
+     * Thumbprint for the `rel` attribute.
      */
     rel?: string;
     /**

--- a/packages/thumbprint-react/components/Link/index.tsx
+++ b/packages/thumbprint-react/components/Link/index.tsx
@@ -9,6 +9,7 @@ interface CommonProps {
     children?: React.ReactNode;
     isDisabled?: boolean;
     onClick?: () => void;
+    rel?: string;
     dataTestId?: string;
     dataTest?: string;
     accessibilityLabel?: string;
@@ -24,6 +25,7 @@ const getCommonLinkProps = (props: CommonProps): CommonProps => {
     return {
         to: props.to,
         onClick: props.onClick,
+        rel: props.rel,
         target: props.target,
         shouldOpenInNewTab: props.shouldOpenInNewTab,
         isDisabled: props.isDisabled,
@@ -42,6 +44,7 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkPropTypes>(
         {
             to,
             onClick,
+            rel,
             target,
             shouldOpenInNewTab = false,
             isDisabled = false,
@@ -59,6 +62,7 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkPropTypes>(
             {...getCommonLinkProps({
                 to,
                 onClick,
+                rel,
                 target,
                 shouldOpenInNewTab,
                 isDisabled,
@@ -99,6 +103,11 @@ interface LinkPropTypes {
      * Function to fire when clicking on the anchor. This should be used alongside the `to` prop.
      */
     onClick?: () => void;
+    /**
+     * The anchor `rel` attribute. Setting this value will override any default value provided by
+     * thumbprint for the `rel` attribute.
+     */
+    rel?: string;
     /**
      * Icon from [Thumbprint Icons](/icons/) to render left of the text within `Link`.
      */
@@ -142,6 +151,7 @@ const ThemedLink = React.forwardRef<HTMLAnchorElement, ThemedLinkPropTypes>(
         {
             to,
             onClick,
+            rel,
             shouldOpenInNewTab = false,
             target,
             isDisabled = false,
@@ -161,6 +171,7 @@ const ThemedLink = React.forwardRef<HTMLAnchorElement, ThemedLinkPropTypes>(
             {...getCommonLinkProps({
                 to,
                 onClick,
+                rel,
                 shouldOpenInNewTab,
                 target,
                 isDisabled,
@@ -201,6 +212,11 @@ interface ThemedLinkPropTypes {
      * Function to fire when clicking on the anchor. This should be used alongside the `to` prop.
      */
     onClick?: () => void;
+    /**
+     * The anchor `rel` attribute. Setting this value will override any default value provided by
+     * thumbprint for the `rel` attribute.
+     */
+    rel?: string;
     /**
      * The anchor `target` attribute. Set this to `_blank` to open in a new tab, or to an arbitrary
      * string to open the link in an `<iframe>` with the same `name`.

--- a/packages/thumbprint-react/components/Link/test.tsx
+++ b/packages/thumbprint-react/components/Link/test.tsx
@@ -70,6 +70,21 @@ test('adds `rel` attribute to handle security vulnerability for `target=_blank`'
     testComponent(ThemedLink);
 });
 
+test('adds `rel` attribute when explicitly defined', () => {
+    const testComponent = (Component: React.ElementType): void => {
+        const wrapperLink = mount(
+            <Component target="_blank" to="https://example.com/" rel="nofollow">
+                Goose
+            </Component>,
+        );
+        expect(wrapperLink.find('a').prop('rel')).toEqual('nofollow noopener noreferrer');
+        expect(wrapperLink).toMatchSnapshot();
+    };
+
+    testComponent(Link);
+    testComponent(ThemedLink);
+});
+
 test('adds attribute to open link in new tab', () => {
     const testComponent = (Component: React.ElementType): void => {
         const wrapperLink = mount(

--- a/packages/thumbprint-react/components/UIAction/__snapshots__/test.tsx.snap
+++ b/packages/thumbprint-react/components/UIAction/__snapshots__/test.tsx.snap
@@ -1,5 +1,41 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Plain <a> adds \`rel="noopener noreferrer"\` attribute for external links and does not duplicate, if duplicate is provided 1`] = `
+<ForwardRef
+  rel="nofollow noopener"
+  shouldOpenInNewTab={true}
+  to="https://example.com/"
+>
+  <a
+    className="plain plainThemePrimary"
+    disabled={false}
+    href="https://example.com/"
+    rel="nofollow noopener noreferrer"
+    target="_blank"
+  >
+    Goose
+  </a>
+</ForwardRef>
+`;
+
+exports[`Plain <a> adds \`rel="noopener noreferrer"\` attribute for external links and respects any provided attributes 1`] = `
+<ForwardRef
+  rel="nofollow"
+  shouldOpenInNewTab={true}
+  to="https://example.com/"
+>
+  <a
+    className="plain plainThemePrimary"
+    disabled={false}
+    href="https://example.com/"
+    rel="nofollow noopener noreferrer"
+    target="_blank"
+  >
+    Goose
+  </a>
+</ForwardRef>
+`;
+
 exports[`Plain <a> adds \`rel="noopener noreferrer"\` attribute for external links to handle security vulnerability 1`] = `
 <ForwardRef
   shouldOpenInNewTab={true}
@@ -519,6 +555,50 @@ exports[`Plain renders tertiary theme 2`] = `
   >
     Goose
   </button>
+</ForwardRef>
+`;
+
+exports[`Themed <a> adds \`rel="noopener noreferrer"\` attribute for external links and does not duplicate, if duplicate is provided 1`] = `
+<ForwardRef
+  rel="nofollow noopener"
+  shouldOpenInNewTab={true}
+  to="https://example.com/"
+>
+  <a
+    className="themedButton themedButtonRoundedBordersLeft themedButtonRoundedBordersRight themedButtonThemePrimary themedButtonWidthAuto"
+    disabled={false}
+    href="https://example.com/"
+    rel="nofollow noopener noreferrer"
+    target="_blank"
+  >
+    <span
+      className="flexWrapper flexWrapperSizeLarge"
+    >
+      Goose
+    </span>
+  </a>
+</ForwardRef>
+`;
+
+exports[`Themed <a> adds \`rel="noopener noreferrer"\` attribute for external links and respects any provided attributes 1`] = `
+<ForwardRef
+  rel="nofollow"
+  shouldOpenInNewTab={true}
+  to="https://example.com/"
+>
+  <a
+    className="themedButton themedButtonRoundedBordersLeft themedButtonRoundedBordersRight themedButtonThemePrimary themedButtonWidthAuto"
+    disabled={false}
+    href="https://example.com/"
+    rel="nofollow noopener noreferrer"
+    target="_blank"
+  >
+    <span
+      className="flexWrapper flexWrapperSizeLarge"
+    >
+      Goose
+    </span>
+  </a>
 </ForwardRef>
 `;
 

--- a/packages/thumbprint-react/components/UIAction/plain.tsx
+++ b/packages/thumbprint-react/components/UIAction/plain.tsx
@@ -15,6 +15,7 @@ const Plain = React.forwardRef<HTMLAnchorElement | HTMLButtonElement, PropTypes>
             iconRight,
             theme = 'primary',
             type = 'button',
+            rel,
             target,
             shouldOpenInNewTab = false,
             onClick,
@@ -78,7 +79,14 @@ const Plain = React.forwardRef<HTMLAnchorElement | HTMLButtonElement, PropTypes>
             return (
                 <a // eslint-disable-line jsx-a11y/anchor-has-content
                     {...commonProps}
-                    {...getAnchorProps({ isDisabled, target, shouldOpenInNewTab, to, onClick })}
+                    {...getAnchorProps({
+                        isDisabled,
+                        target,
+                        shouldOpenInNewTab,
+                        to,
+                        onClick,
+                        rel,
+                    })}
                     ref={ref as React.Ref<HTMLAnchorElement>}
                 />
             );
@@ -124,6 +132,11 @@ interface PropTypes {
      * Button’s of type `submit` will submit a form when used within a `form` element.
      */
     type?: 'button' | 'submit';
+    /**
+     * The anchor `rel` attribute. Setting this value will override any default value provided by
+     * thumbprint for the `rel` attribute.
+     */
+    rel?: string;
     /**
      * The anchor `target` attribute. Set this to `_blank` to open in a new tab, or to an arbitrary
      * string to open the link in an `<iframe>` with the same `name`.

--- a/packages/thumbprint-react/components/UIAction/plain.tsx
+++ b/packages/thumbprint-react/components/UIAction/plain.tsx
@@ -133,8 +133,8 @@ interface PropTypes {
      */
     type?: 'button' | 'submit';
     /**
-     * The anchor `rel` attribute. Setting this value will override any default value provided by
-     * thumbprint for the `rel` attribute.
+     * The anchor `rel` attribute. Setting this value will add to any defalut values provided by
+     * Thumbprint for the `rel` attribute.
      */
     rel?: string;
     /**

--- a/packages/thumbprint-react/components/UIAction/test.tsx
+++ b/packages/thumbprint-react/components/UIAction/test.tsx
@@ -39,6 +39,26 @@ describe('Plain', (): void => {
             expect(wrapper).toMatchSnapshot();
         });
 
+        test('adds `rel="noopener noreferrer"` attribute for external links and respects any provided attributes', (): void => {
+            const wrapper = mount(
+                <Plain shouldOpenInNewTab to="https://example.com/" rel="nofollow">
+                    Goose
+                </Plain>,
+            );
+            expect(wrapper.find('a').prop('rel')).toEqual('nofollow noopener noreferrer');
+            expect(wrapper).toMatchSnapshot();
+        });
+
+        test('adds `rel="noopener noreferrer"` attribute for external links and does not duplicate, if duplicate is provided', (): void => {
+            const wrapper = mount(
+                <Plain shouldOpenInNewTab to="https://example.com/" rel="nofollow noopener">
+                    Goose
+                </Plain>,
+            );
+            expect(wrapper.find('a').prop('rel')).toEqual('nofollow noopener noreferrer');
+            expect(wrapper).toMatchSnapshot();
+        });
+
         test('adds `rel="noopener"` attribute for internal links that open new tab', (): void => {
             const wrapperDomain = mount(
                 <Plain shouldOpenInNewTab to="https://www.thumbtack.com/foo">
@@ -321,6 +341,26 @@ describe('Themed', (): void => {
                 </Themed>,
             );
             expect(wrapper.find('a').prop('rel')).toEqual('noopener noreferrer');
+            expect(wrapper).toMatchSnapshot();
+        });
+
+        test('adds `rel="noopener noreferrer"` attribute for external links and respects any provided attributes', (): void => {
+            const wrapper = mount(
+                <Themed shouldOpenInNewTab to="https://example.com/" rel="nofollow">
+                    Goose
+                </Themed>,
+            );
+            expect(wrapper.find('a').prop('rel')).toEqual('nofollow noopener noreferrer');
+            expect(wrapper).toMatchSnapshot();
+        });
+
+        test('adds `rel="noopener noreferrer"` attribute for external links and does not duplicate, if duplicate is provided', (): void => {
+            const wrapper = mount(
+                <Themed shouldOpenInNewTab to="https://example.com/" rel="nofollow noopener">
+                    Goose
+                </Themed>,
+            );
+            expect(wrapper.find('a').prop('rel')).toEqual('nofollow noopener noreferrer');
             expect(wrapper).toMatchSnapshot();
         });
 

--- a/packages/thumbprint-react/components/UIAction/themed.tsx
+++ b/packages/thumbprint-react/components/UIAction/themed.tsx
@@ -92,6 +92,7 @@ const Themed = React.forwardRef<HTMLButtonElement | HTMLAnchorElement, PropTypes
             type = 'button',
             to,
             shouldOpenInNewTab = false,
+            rel,
             target,
             onClick,
             onMouseEnter,
@@ -122,6 +123,7 @@ const Themed = React.forwardRef<HTMLButtonElement | HTMLAnchorElement, PropTypes
                         shouldOpenInNewTab,
                         to,
                         onClick,
+                        rel,
                         target,
                     });
                     const buttonProps = getButtonProps({
@@ -247,6 +249,11 @@ interface PropTypes {
      * This is deprecated. Use `target="_blank"` instead.
      */
     shouldOpenInNewTab?: boolean;
+    /**
+     * The anchor `rel` attribute. Setting this value will override any default value provided by
+     * thumbprint for the `rel` attribute.
+     */
+    rel?: string;
     /**
      * The anchor `target` attribute. Set this to `_blank` to open in a new tab, or to an arbitrary
      * string to open the link in an `<iframe>` with the same `name`.

--- a/packages/thumbprint-react/components/UIAction/themed.tsx
+++ b/packages/thumbprint-react/components/UIAction/themed.tsx
@@ -250,8 +250,8 @@ interface PropTypes {
      */
     shouldOpenInNewTab?: boolean;
     /**
-     * The anchor `rel` attribute. Setting this value will override any default value provided by
-     * thumbprint for the `rel` attribute.
+     * The anchor `rel` attribute. Setting this value will add to any default values provided by
+     * Thumbprint for the `rel` attribute.
      */
     rel?: string;
     /**


### PR DESCRIPTION
We wanted the ability to define `rel` attribute values on the `ThemedLink` component (specifically, `rel='nofollow'`) for SEO purposes. 

It looks like there is already some default `rel` definition behavior in the UIAction directory, mainly for anchor elements - the intent of this PR is that we do not affect any existing rel definition and instead add any new definitions (without duplication) to the existing definitions. 