### PR TITLE
Fix issue where Thumbprint Tokens GraphQL endpoint breaks build

### DIFF
--- a/www/gatsby-config.js
+++ b/www/gatsby-config.js
@@ -105,7 +105,7 @@ module.exports = {
             options: {
                 typeName: 'ThumbprintToken',
                 fieldName: 'thumbprintToken',
-                url: 'https://thumbprint-tokens.netlify.com/',
+                url: 'https://thumbprint-tokens.netlify.app/.netlify/functions/graphql',
             },
         },
         'gatsby-transformer-thumbprint-atomic',


### PR DESCRIPTION
We're running into an issue where builds are broken because the GraphQL endpoint for tokens isn't working. It fails with this error:

```
 ERROR #11321  PLUGIN

"gatsby-source-graphql" threw an error while running the sourceNodes lifecycle:

Unexpected token G in JSON at position 0

  ServerParseError: Unexpected token G in JSON at position 0

  - JSON.parse

  - index.js:35
    [thumbprint]/[apollo-link-http-common]/lib/index.js:35:25

  - runMicrotasks
```

Changing the URL to the server seems to fix it. I imagine something changed on Netlify's end that prevents the request proxying from working.