### PR TITLE
Add an `accessibilityLabel` prop to the `Dropdown` component

### DIFF
--- a/packages/thumbprint-react/CHANGELOG.md
+++ b/packages/thumbprint-react/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 -   [Patch] Support new `fetchPriority` feature in Chrome for loading images
+-   [Minor] Add an `accessibilityLabel` prop to `Dropdown`
 
 ## 14.6.0 - 2022-03-21
 

--- a/packages/thumbprint-react/components/Dropdown/__snapshots__/test.tsx.snap
+++ b/packages/thumbprint-react/components/Dropdown/__snapshots__/test.tsx.snap
@@ -1,5 +1,42 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`adds \`accessibilityLabel\` prop 1`] = `
+<Dropdown
+  accessibilityLabel="Choose your business"
+  onChange={[Function]}
+  value="foo"
+>
+  <div
+    className="root"
+  >
+    <select
+      aria-label="Choose your business"
+      className="select selectStateDefault selectSizeLarge"
+      disabled={false}
+      onChange={[Function]}
+      onClick={[Function]}
+      required={false}
+      value="foo"
+    />
+    <svg
+      className="caret"
+      fill="none"
+      height="18"
+      stroke="#2f3033"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth="3"
+      viewBox="0 0 24 24"
+      width="18"
+    >
+      <polyline
+        points="6 9 12 15 18 9"
+      />
+    </svg>
+  </div>
+</Dropdown>
+`;
+
 exports[`adds \`dataTest\` prop 1`] = `
 <Dropdown
   dataTest="Duck"

--- a/packages/thumbprint-react/components/Dropdown/index.tsx
+++ b/packages/thumbprint-react/components/Dropdown/index.tsx
@@ -96,9 +96,16 @@ export interface DropdownProps<T extends string | number> {
      * selected value.
      */
     name?: string;
+    /**
+     * This adds an `aria-label` to the element. It should only be used in cases where the
+     * `<Dropdown>` doesn't have or can't be associated with a related `<label>`. [Learn more about
+     * the importance of using labels](https://dequeuniversity.com/rules/axe/4.3/select-name).
+     */
+    accessibilityLabel?: string;
 }
 
 export default function Dropdown<T extends string | number = string>({
+    accessibilityLabel,
     children,
     dataTest,
     dataTestId,
@@ -143,6 +150,7 @@ export default function Dropdown<T extends string | number = string>({
                 onBlur={onBlur}
                 data-testid={dataTestId}
                 data-test={dataTest}
+                aria-label={accessibilityLabel}
                 name={name}
             >
                 {children}

--- a/packages/thumbprint-react/components/Dropdown/test.tsx
+++ b/packages/thumbprint-react/components/Dropdown/test.tsx
@@ -105,6 +105,14 @@ test('adds `dataTestId` prop', () => {
     expect(wrapperA).toMatchSnapshot();
 });
 
+test('adds `accessibilityLabel` prop', () => {
+    const wrapperA = mount(
+        <Dropdown accessibilityLabel="Choose your business" onChange={noop} value="foo" />,
+    );
+    expect(wrapperA.find('select').prop('aria-label')).toEqual('Choose your business');
+    expect(wrapperA).toMatchSnapshot();
+});
+
 test('adds `name` HTML attribute', () => {
     const wrapperA = mount(<Dropdown name="duck" onChange={noop} value="goose" />);
     expect(wrapperA.find('select').prop('name')).toEqual('duck');


### PR DESCRIPTION
This follows a naming pattern set in other components where `accessibilityLabel` is used for the `aria-*` functionality.