### PR TITLE
Rename `fetchPriority` to `fetchpriority` so that it works with React.

### DIFF
--- a/packages/thumbprint-react/CHANGELOG.md
+++ b/packages/thumbprint-react/CHANGELOG.md
@@ -7,6 +7,10 @@
 -   [Patch] Support new `fetchPriority` feature in Chrome for loading images
 -   [Minor] Add an `accessibilityLabel` prop to `Dropdown`
 
+### Fixed
+
+-   [Patch] Rename `fetchPriority` to `fetchpriority` so that it works with React.
+
 ## 14.6.0 - 2022-03-21
 
 ### Changed

--- a/packages/thumbprint-react/components/Avatar/__snapshots__/test.tsx.snap
+++ b/packages/thumbprint-react/components/Avatar/__snapshots__/test.tsx.snap
@@ -25,7 +25,7 @@ exports[`EntityAvatar renders an image when the user has one 1`] = `
         <img
           alt=""
           className="imageStart"
-          fetchPriority="auto"
+          fetchpriority="auto"
           height="48px"
           onError={[Function]}
           onLoad={[Function]}
@@ -103,7 +103,7 @@ exports[`adds the \`fullName\` as \`alt\` text when image is provided 1`] = `
         <img
           alt="Avatar for Duck Goose"
           className="imageStart"
-          fetchPriority="auto"
+          fetchpriority="auto"
           height="48px"
           onError={[Function]}
           onLoad={[Function]}
@@ -180,7 +180,7 @@ exports[`adds the \`fullName\` as \`title\` text 2`] = `
         <img
           alt="Avatar for Duck Goose"
           className="imageStart"
-          fetchPriority="auto"
+          fetchpriority="auto"
           height="48px"
           onError={[Function]}
           onLoad={[Function]}
@@ -662,7 +662,7 @@ exports[`renders an image when the user has one 1`] = `
         <img
           alt=""
           className="imageStart"
-          fetchPriority="auto"
+          fetchpriority="auto"
           height="48px"
           onError={[Function]}
           onLoad={[Function]}

--- a/packages/thumbprint-react/components/Image/index.tsx
+++ b/packages/thumbprint-react/components/Image/index.tsx
@@ -292,7 +292,7 @@ const Image = forwardRef<HTMLElement, ImageProps>((props: ImageProps, outerRef) 
                     // We expect an error because the attribute is non-standard and doesn't yet
                     // exist in the React types.
                     // @ts-expect-error
-                    fetchPriority={forceEarlyRender ? 'high' : 'auto'}
+                    fetchpriority={forceEarlyRender ? 'high' : 'auto'}
                     className={classNames({
                         // Opacity to 0, prevents flash of alt text when `height` prop used
                         [styles.imageStart]: true,

--- a/packages/thumbprint-react/components/ServiceCard/__snapshots__/test.tsx.snap
+++ b/packages/thumbprint-react/components/ServiceCard/__snapshots__/test.tsx.snap
@@ -79,7 +79,7 @@ exports[`ServiceCardImage render works 1`] = `
       <img
         alt="duck duck goose"
         className="imageStart"
-        fetchPriority="auto"
+        fetchpriority="auto"
         onError={[Function]}
         onLoad={[Function]}
         sizes="0px"


### PR DESCRIPTION
I didn't do enough testing of the original commit and recently noticed that it's was printing a warning in the console:

> Warning: React does not recognize the `fetchPriority` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase
`fetchpriority` instead. If you accidentally passed it from a parent component, remove it from the DOM element.

Making it all lowercase fixes the problem.