### PR TITLE
Switch to Dart Sass in gastby-transformer-atomic

### DIFF
--- a/packages/gatsby-transformer-thumbprint-atomic/gatsby-node.js
+++ b/packages/gatsby-transformer-thumbprint-atomic/gatsby-node.js
@@ -1,4 +1,4 @@
-const sass = require('node-sass');
+const sass = require('sass');
 const crypto = require('crypto');
 const importer = require('node-sass-tilde-importer');
 const parseAst = require('./parse-ast');

--- a/packages/gatsby-transformer-thumbprint-atomic/package.json
+++ b/packages/gatsby-transformer-thumbprint-atomic/package.json
@@ -5,8 +5,8 @@
     "dependencies": {
         "gonzales-pe": "^4.2.4",
         "lodash": "^4.17.10",
-        "node-sass": "^4.11.0",
         "node-sass-tilde-importer": "2.0.0-alpha.1",
-        "prettier": "2.0.5"
+        "prettier": "2.0.5",
+        "sass": "^1.51.0"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -15061,7 +15061,7 @@ node-sass-tilde-importer@2.0.0-alpha.1:
   dependencies:
     find-parent-dir "^0.3.0"
 
-node-sass@^4.11.0, node-sass@^4.9.2:
+node-sass@^4.9.2:
   version "4.12.0"
   resolved "https://registry.yarnpkg.com/node-sass/-/node-sass-4.12.0.tgz#0914f531932380114a30cc5fa4fa63233a25f017"
   integrity sha512-A1Iv4oN+Iel6EPv77/HddXErL2a+gZ4uBeZUy+a8O35CFYTXhgA8MgLCWBtwpGZdCvTvQ9d+bQxX/QC36GDPpQ==


### PR DESCRIPTION
Tested by running `yarn start`. Atomic docs still load and show correct values.