### PR TITLE
Add unit test for ModalCurtain unmount cleanup

### DIFF
--- a/packages/thumbprint-react/components/ModalCurtain/test.tsx
+++ b/packages/thumbprint-react/components/ModalCurtain/test.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { render, screen } from '@testing-library/react';
 import ModalCurtain from './index';
+import { mount } from 'enzyme';
 
 const ESC_KEY = 27;
 const ENTER_KEY = 13;
@@ -196,9 +197,22 @@ describe('ModalCurtain', () => {
 
         expect(onCloseClick).toHaveBeenCalledTimes(0);
     });
+    test('Cleans up DOM on unmount enzyme', () => {
+        const wrapper = mount(<ModalCurtain onCloseClick={jest.fn} stage="entered" />);
+        screen.debug();
+        wrapper.unmount();
+    });
 
-    test.only('Cleans up DOM on unmount', () => {
+    test('Cleans up DOM on unmount with RTL and Enzyme', () => {
         const onCloseClick = jest.fn();
+        const wrapper1 = mount(<ModalCurtain stage="entered" onCloseClick={onCloseClick} />);
+
+        expect(screen.queryByRole('dialog')).toBeInTheDocument();
+
+        wrapper1.unmount();
+
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+
         const wrapper = render(<ModalCurtain stage="entered" onCloseClick={onCloseClick} />);
 
         expect(screen.queryByRole('dialog')).toBeInTheDocument();

--- a/packages/thumbprint-react/components/ModalCurtain/test.tsx
+++ b/packages/thumbprint-react/components/ModalCurtain/test.tsx
@@ -197,6 +197,19 @@ describe('ModalCurtain', () => {
         expect(onCloseClick).toHaveBeenCalledTimes(0);
     });
 
+    test.only('Cleans up DOM on unmount', () => {
+        const onCloseClick = jest.fn();
+        const wrapper = render(<ModalCurtain stage="entered" onCloseClick={onCloseClick} />);
+
+        expect(screen.queryByRole('dialog')).toBeInTheDocument();
+        console.log(screen.debug());
+
+        wrapper.unmount();
+        console.log(screen.debug());
+
+        expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+
     describe('closes modal on `ESC`', () => {
         test('when modal is open and `shouldCloseOnEscape` is `true`', () => {
             const onCloseClick = jest.fn();

--- a/packages/thumbprint-react/utils/ConditionalPortal.tsx
+++ b/packages/thumbprint-react/utils/ConditionalPortal.tsx
@@ -22,15 +22,26 @@ export default function ConditionalPortal({
     shouldDisplace = false,
     children,
 }: PropTypes): JSX.Element | null {
+    const [container] = React.useState(() => {
+        const el = document.createElement('div');
+        el.classList.add('root-portal');
+        return el;
+    });
+
+    React.useEffect(() => {
+        document.body.appendChild(container);
+        return () => {
+            document.body.removeChild(container);
+        };
+    }, []);
+
     if (!children) {
         return null;
     }
 
     return (
         <React.Fragment>
-            {canUseDOM && shouldDisplace
-                ? ReactDOM.createPortal(children, document.body)
-                : children}
+            {canUseDOM && shouldDisplace ? ReactDOM.createPortal(children, container) : children}
         </React.Fragment>
     );
 }


### PR DESCRIPTION
So I'm pretty confused. This test passes, and the `screen.debug()` calls show what you'd expect. We can still add this unit test, but it doesn't explain why the RF tests were failing.