### PR TITLE
Add onKeyDown prop to Radio and Checkbox

### DIFF
--- a/packages/thumbprint-react/CHANGELOG.md
+++ b/packages/thumbprint-react/CHANGELOG.md
@@ -5,7 +5,8 @@
 ### Added
 
 -   [Minor] Pass `event` object as argument to `onChange` prop of the `Radio` and `Checkbox` components
--   [Minor] Add `onKeyPress` prop to the `Radio` and `Checkbox` components
+-   [Minor] Add `onKeyDown` prop to the `Radio` and `Checkbox` components
+-   [Patch] Mark `onKeyPress` prop of `TextInput` component as deprecated.
 
 ## 14.10.0 - 2022-05-09
 

--- a/packages/thumbprint-react/CHANGELOG.md
+++ b/packages/thumbprint-react/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+-   [Minor] Pass `event` object as argument to `onChange` prop of the `Radio` and `Checkbox` components.
+
 ## 14.10.0 - 2022-05-09
 
 ### Added

--- a/packages/thumbprint-react/CHANGELOG.md
+++ b/packages/thumbprint-react/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Added
 
--   [Minor] Pass `event` object as argument to `onChange` prop of the `Radio` and `Checkbox` components.
+-   [Minor] Pass `event` object as argument to `onChange` prop of the `Radio` and `Checkbox` components
+-   [Minor] Add `onKeyPress` prop to the `Radio` and `Checkbox` components
 
 ## 14.10.0 - 2022-05-09
 

--- a/packages/thumbprint-react/components/Checkbox/__snapshots__/test.tsx.snap
+++ b/packages/thumbprint-react/components/Checkbox/__snapshots__/test.tsx.snap
@@ -21,6 +21,7 @@ exports[`adds \`dataTest\` prop 1`] = `
       data-test="Duck"
       disabled={false}
       onChange={[Function]}
+      onKeyPress={[Function]}
       required={false}
       type="checkbox"
     />
@@ -69,6 +70,7 @@ exports[`adds \`dataTestId\` prop 1`] = `
       data-testid="Duck"
       disabled={false}
       onChange={[Function]}
+      onKeyPress={[Function]}
       required={false}
       type="checkbox"
     />
@@ -116,6 +118,7 @@ exports[`adds \`disabled\` attribute 1`] = `
       className="input"
       disabled={true}
       onChange={[Function]}
+      onKeyPress={[Function]}
       required={false}
       type="checkbox"
     />
@@ -164,6 +167,7 @@ exports[`adds \`name\` attribute 1`] = `
       disabled={false}
       name="ohhi"
       onChange={[Function]}
+      onKeyPress={[Function]}
       required={false}
       type="checkbox"
     />
@@ -211,6 +215,7 @@ exports[`adds \`value\` prop 1`] = `
       className="input"
       disabled={false}
       onChange={[Function]}
+      onKeyPress={[Function]}
       required={false}
       type="checkbox"
       value="Duck"
@@ -259,6 +264,7 @@ exports[`applies \`labelPadding\` as padding on the label 1`] = `
       className="input"
       disabled={false}
       onChange={[Function]}
+      onKeyPress={[Function]}
       required={false}
       type="checkbox"
     />
@@ -306,6 +312,7 @@ exports[`applies className corresponding to \`checkboxVerticalAlign\` on the lab
       className="input"
       disabled={false}
       onChange={[Function]}
+      onKeyPress={[Function]}
       required={false}
       type="checkbox"
     />
@@ -354,6 +361,7 @@ exports[`if no \`children\` are passed in 1`] = `
       disabled={false}
       id="no-children"
       onChange={[Function]}
+      onKeyPress={[Function]}
       required={false}
       type="checkbox"
     />
@@ -391,6 +399,7 @@ exports[`is checked when \`isChecked\` is set to true 1`] = `
       className="input"
       disabled={false}
       onChange={[Function]}
+      onKeyPress={[Function]}
       required={false}
       type="checkbox"
     />
@@ -465,6 +474,7 @@ exports[`is not checked by default 1`] = `
       className="input"
       disabled={false}
       onChange={[Function]}
+      onKeyPress={[Function]}
       required={false}
       type="checkbox"
     />
@@ -511,6 +521,7 @@ exports[`renders \`children\` passed in 1`] = `
       className="input"
       disabled={false}
       onChange={[Function]}
+      onKeyPress={[Function]}
       required={false}
       type="checkbox"
     />
@@ -559,6 +570,7 @@ exports[`renders \`hasError\` state 1`] = `
       className="input"
       disabled={false}
       onChange={[Function]}
+      onKeyPress={[Function]}
       required={false}
       type="checkbox"
     />
@@ -634,6 +646,7 @@ exports[`renders \`hasError\` state 2`] = `
       className="input"
       disabled={false}
       onChange={[Function]}
+      onKeyPress={[Function]}
       required={false}
       type="checkbox"
     />
@@ -680,6 +693,7 @@ exports[`renders \`input\` within \`label\` 1`] = `
       className="input"
       disabled={false}
       onChange={[Function]}
+      onKeyPress={[Function]}
       required={false}
       type="checkbox"
     />
@@ -726,6 +740,7 @@ exports[`renders checkbox input 1`] = `
       className="input"
       disabled={false}
       onChange={[Function]}
+      onKeyPress={[Function]}
       required={false}
       type="checkbox"
     />
@@ -774,6 +789,7 @@ exports[`renders indeterminate SVG when both \`isIndeterminate\` and \`isChecked
       className="input"
       disabled={false}
       onChange={[Function]}
+      onKeyPress={[Function]}
       required={false}
       type="checkbox"
     />

--- a/packages/thumbprint-react/components/Checkbox/__snapshots__/test.tsx.snap
+++ b/packages/thumbprint-react/components/Checkbox/__snapshots__/test.tsx.snap
@@ -21,7 +21,7 @@ exports[`adds \`dataTest\` prop 1`] = `
       data-test="Duck"
       disabled={false}
       onChange={[Function]}
-      onKeyPress={[Function]}
+      onKeyDown={[Function]}
       required={false}
       type="checkbox"
     />
@@ -70,7 +70,7 @@ exports[`adds \`dataTestId\` prop 1`] = `
       data-testid="Duck"
       disabled={false}
       onChange={[Function]}
-      onKeyPress={[Function]}
+      onKeyDown={[Function]}
       required={false}
       type="checkbox"
     />
@@ -118,7 +118,7 @@ exports[`adds \`disabled\` attribute 1`] = `
       className="input"
       disabled={true}
       onChange={[Function]}
-      onKeyPress={[Function]}
+      onKeyDown={[Function]}
       required={false}
       type="checkbox"
     />
@@ -167,7 +167,7 @@ exports[`adds \`name\` attribute 1`] = `
       disabled={false}
       name="ohhi"
       onChange={[Function]}
-      onKeyPress={[Function]}
+      onKeyDown={[Function]}
       required={false}
       type="checkbox"
     />
@@ -215,7 +215,7 @@ exports[`adds \`value\` prop 1`] = `
       className="input"
       disabled={false}
       onChange={[Function]}
-      onKeyPress={[Function]}
+      onKeyDown={[Function]}
       required={false}
       type="checkbox"
       value="Duck"
@@ -264,7 +264,7 @@ exports[`applies \`labelPadding\` as padding on the label 1`] = `
       className="input"
       disabled={false}
       onChange={[Function]}
-      onKeyPress={[Function]}
+      onKeyDown={[Function]}
       required={false}
       type="checkbox"
     />
@@ -312,7 +312,7 @@ exports[`applies className corresponding to \`checkboxVerticalAlign\` on the lab
       className="input"
       disabled={false}
       onChange={[Function]}
-      onKeyPress={[Function]}
+      onKeyDown={[Function]}
       required={false}
       type="checkbox"
     />
@@ -361,7 +361,7 @@ exports[`if no \`children\` are passed in 1`] = `
       disabled={false}
       id="no-children"
       onChange={[Function]}
-      onKeyPress={[Function]}
+      onKeyDown={[Function]}
       required={false}
       type="checkbox"
     />
@@ -399,7 +399,7 @@ exports[`is checked when \`isChecked\` is set to true 1`] = `
       className="input"
       disabled={false}
       onChange={[Function]}
-      onKeyPress={[Function]}
+      onKeyDown={[Function]}
       required={false}
       type="checkbox"
     />
@@ -474,7 +474,7 @@ exports[`is not checked by default 1`] = `
       className="input"
       disabled={false}
       onChange={[Function]}
-      onKeyPress={[Function]}
+      onKeyDown={[Function]}
       required={false}
       type="checkbox"
     />
@@ -521,7 +521,7 @@ exports[`renders \`children\` passed in 1`] = `
       className="input"
       disabled={false}
       onChange={[Function]}
-      onKeyPress={[Function]}
+      onKeyDown={[Function]}
       required={false}
       type="checkbox"
     />
@@ -570,7 +570,7 @@ exports[`renders \`hasError\` state 1`] = `
       className="input"
       disabled={false}
       onChange={[Function]}
-      onKeyPress={[Function]}
+      onKeyDown={[Function]}
       required={false}
       type="checkbox"
     />
@@ -646,7 +646,7 @@ exports[`renders \`hasError\` state 2`] = `
       className="input"
       disabled={false}
       onChange={[Function]}
-      onKeyPress={[Function]}
+      onKeyDown={[Function]}
       required={false}
       type="checkbox"
     />
@@ -693,7 +693,7 @@ exports[`renders \`input\` within \`label\` 1`] = `
       className="input"
       disabled={false}
       onChange={[Function]}
-      onKeyPress={[Function]}
+      onKeyDown={[Function]}
       required={false}
       type="checkbox"
     />
@@ -740,7 +740,7 @@ exports[`renders checkbox input 1`] = `
       className="input"
       disabled={false}
       onChange={[Function]}
-      onKeyPress={[Function]}
+      onKeyDown={[Function]}
       required={false}
       type="checkbox"
     />
@@ -789,7 +789,7 @@ exports[`renders indeterminate SVG when both \`isIndeterminate\` and \`isChecked
       className="input"
       disabled={false}
       onChange={[Function]}
-      onKeyPress={[Function]}
+      onKeyDown={[Function]}
       required={false}
       type="checkbox"
     />

--- a/packages/thumbprint-react/components/Checkbox/index.tsx
+++ b/packages/thumbprint-react/components/Checkbox/index.tsx
@@ -142,10 +142,15 @@ export interface CheckboxProps {
      */
     labelPadding?: string;
     /**
-     * Function that runs when a checkbox value changes. It receives the new boolean value and
-     * the provided `id` as such: `props.onChange(e.target.checked, props.id)`.
+     * Function that runs when a checkbox value changes. It receives the new boolean value,
+     * the provided `id`, and the underlying `event` as such:
+     * `props.onChange(event.target.checked, props.id, event)`.
      */
-    onChange: (value: boolean, id?: string) => void;
+    onChange: (
+        value: boolean,
+        id: string | undefined,
+        event: React.ChangeEvent<HTMLInputElement>,
+    ) => void;
     /**
      * Shows a horizontal line to represent an indeterminate input.
      */
@@ -221,7 +226,7 @@ export default function Checkbox({
                 id={id}
                 name={name}
                 checked={isChecked}
-                onChange={(event): void => onChange(event.target.checked, id)}
+                onChange={(event): void => onChange(event.target.checked, id, event)}
                 disabled={isDisabled}
                 required={isRequired}
                 {...valuePropObject}

--- a/packages/thumbprint-react/components/Checkbox/index.tsx
+++ b/packages/thumbprint-react/components/Checkbox/index.tsx
@@ -152,6 +152,10 @@ export interface CheckboxProps {
         event: React.ChangeEvent<HTMLInputElement>,
     ) => void;
     /**
+     * Function that is called when the user presses a key while focused on the Checkbox.
+     */
+    onKeyPress?: (event: React.KeyboardEvent<HTMLInputElement>) => void;
+    /**
      * Shows a horizontal line to represent an indeterminate input.
      */
     isIndeterminate?: boolean;
@@ -191,6 +195,7 @@ export default function Checkbox({
     isRequired = false,
     name,
     onChange,
+    onKeyPress = (): void => {},
     value,
 }: CheckboxProps): JSX.Element {
     const functionalState = getFunctionalState({ isDisabled, hasError });
@@ -226,7 +231,12 @@ export default function Checkbox({
                 id={id}
                 name={name}
                 checked={isChecked}
-                onChange={(event): void => onChange(event.target.checked, id, event)}
+                onChange={(event): void => {
+                    onChange(event.target.checked, id, event);
+                }}
+                onKeyPress={(event): void => {
+                    onKeyPress(event);
+                }}
                 disabled={isDisabled}
                 required={isRequired}
                 {...valuePropObject}

--- a/packages/thumbprint-react/components/Checkbox/index.tsx
+++ b/packages/thumbprint-react/components/Checkbox/index.tsx
@@ -154,7 +154,7 @@ export interface CheckboxProps {
     /**
      * Function that is called when the user presses a key while focused on the Checkbox.
      */
-    onKeyPress?: (event: React.KeyboardEvent<HTMLInputElement>) => void;
+    onKeyDown?: (event: React.KeyboardEvent<HTMLInputElement>) => void;
     /**
      * Shows a horizontal line to represent an indeterminate input.
      */
@@ -195,7 +195,7 @@ export default function Checkbox({
     isRequired = false,
     name,
     onChange,
-    onKeyPress = (): void => {},
+    onKeyDown = (): void => {},
     value,
 }: CheckboxProps): JSX.Element {
     const functionalState = getFunctionalState({ isDisabled, hasError });
@@ -234,8 +234,8 @@ export default function Checkbox({
                 onChange={(event): void => {
                     onChange(event.target.checked, id, event);
                 }}
-                onKeyPress={(event): void => {
-                    onKeyPress(event);
+                onKeyDown={(event): void => {
+                    onKeyDown(event);
                 }}
                 disabled={isDisabled}
                 required={isRequired}

--- a/packages/thumbprint-react/components/Checkbox/test.tsx
+++ b/packages/thumbprint-react/components/Checkbox/test.tsx
@@ -121,10 +121,18 @@ test('passes correct new value and `id` to `onChange` function', () => {
     );
 
     wrapper.find('input').simulate('change', { target: { checked: false } });
-    expect(onChange).toHaveBeenCalledWith(false, 'goose');
+    expect(onChange).toHaveBeenCalledWith(
+        false,
+        'goose',
+        expect.objectContaining({ type: 'change' }),
+    );
 
     wrapper.find('input').simulate('change', { target: { checked: true } });
-    expect(onChange).toHaveBeenCalledWith(true, 'goose');
+    expect(onChange).toHaveBeenCalledWith(
+        true,
+        'goose',
+        expect.objectContaining({ type: 'change' }),
+    );
 });
 
 test('calls `onChange` with correct values when `isIndeterminate` is true ', () => {
@@ -136,10 +144,18 @@ test('calls `onChange` with correct values when `isIndeterminate` is true ', () 
     );
 
     wrapper.find('input').simulate('change', { target: { checked: false } });
-    expect(onChange).toHaveBeenCalledWith(false, undefined);
+    expect(onChange).toHaveBeenCalledWith(
+        false,
+        undefined,
+        expect.objectContaining({ type: 'change' }),
+    );
 
     wrapper.find('input').simulate('change', { target: { checked: true } });
-    expect(onChange).toHaveBeenCalledWith(true, undefined);
+    expect(onChange).toHaveBeenCalledWith(
+        true,
+        undefined,
+        expect.objectContaining({ type: 'change' }),
+    );
 });
 
 test('renders indeterminate SVG when both `isIndeterminate` and `isChecked` are true ', () => {

--- a/packages/thumbprint-react/components/Radio/__snapshots__/test.tsx.snap
+++ b/packages/thumbprint-react/components/Radio/__snapshots__/test.tsx.snap
@@ -22,7 +22,7 @@ exports[`adds \`dataTest\` prop 1`] = `
       disabled={false}
       name="duck"
       onChange={[Function]}
-      onKeyPress={[Function]}
+      onKeyDown={[Function]}
       required={false}
       type="radio"
     />
@@ -81,7 +81,7 @@ exports[`adds \`disabled\` attribute 1`] = `
       disabled={true}
       name="duck"
       onChange={[Function]}
-      onKeyPress={[Function]}
+      onKeyDown={[Function]}
       required={false}
       type="radio"
     />
@@ -140,7 +140,7 @@ exports[`applies \`labelPadding\` as padding on the label 1`] = `
       disabled={false}
       name="duck"
       onChange={[Function]}
-      onKeyPress={[Function]}
+      onKeyDown={[Function]}
       required={false}
       type="radio"
     />
@@ -199,7 +199,7 @@ exports[`applies className corresponding to \`radioVerticalAlign\` on the label 
       disabled={false}
       name="duck"
       onChange={[Function]}
-      onKeyPress={[Function]}
+      onKeyDown={[Function]}
       required={false}
       type="radio"
     />
@@ -259,7 +259,7 @@ exports[`if no \`children\` are passed in 1`] = `
       id="no-children"
       name="duck"
       onChange={[Function]}
-      onKeyPress={[Function]}
+      onKeyDown={[Function]}
       required={false}
       type="radio"
     />
@@ -308,7 +308,7 @@ exports[`is checked when \`isChecked\` is set to true 1`] = `
       disabled={false}
       name="duck"
       onChange={[Function]}
-      onKeyPress={[Function]}
+      onKeyDown={[Function]}
       required={false}
       type="radio"
     />
@@ -372,7 +372,7 @@ exports[`is not checked by default 1`] = `
       disabled={false}
       name="duck"
       onChange={[Function]}
-      onKeyPress={[Function]}
+      onKeyDown={[Function]}
       required={false}
       type="radio"
     />
@@ -430,7 +430,7 @@ exports[`renders \`children\` passed in 1`] = `
       disabled={false}
       name="duck"
       onChange={[Function]}
-      onKeyPress={[Function]}
+      onKeyDown={[Function]}
       required={false}
       type="radio"
     />
@@ -489,7 +489,7 @@ exports[`renders \`hasError\` state 1`] = `
       disabled={false}
       name="duck"
       onChange={[Function]}
-      onKeyPress={[Function]}
+      onKeyDown={[Function]}
       required={false}
       type="radio"
     />
@@ -549,7 +549,7 @@ exports[`renders \`hasError\` state 2`] = `
       disabled={false}
       name="duck"
       onChange={[Function]}
-      onKeyPress={[Function]}
+      onKeyDown={[Function]}
       required={false}
       type="radio"
     />
@@ -613,7 +613,7 @@ exports[`renders \`input\` within \`label\` 1`] = `
       disabled={false}
       name="duck"
       onChange={[Function]}
-      onKeyPress={[Function]}
+      onKeyDown={[Function]}
       required={false}
       type="radio"
     />
@@ -671,7 +671,7 @@ exports[`renders radio input 1`] = `
       disabled={false}
       name="duck"
       onChange={[Function]}
-      onKeyPress={[Function]}
+      onKeyDown={[Function]}
       required={false}
       type="radio"
     />

--- a/packages/thumbprint-react/components/Radio/__snapshots__/test.tsx.snap
+++ b/packages/thumbprint-react/components/Radio/__snapshots__/test.tsx.snap
@@ -22,6 +22,7 @@ exports[`adds \`dataTest\` prop 1`] = `
       disabled={false}
       name="duck"
       onChange={[Function]}
+      onKeyPress={[Function]}
       required={false}
       type="radio"
     />
@@ -80,6 +81,7 @@ exports[`adds \`disabled\` attribute 1`] = `
       disabled={true}
       name="duck"
       onChange={[Function]}
+      onKeyPress={[Function]}
       required={false}
       type="radio"
     />
@@ -138,6 +140,7 @@ exports[`applies \`labelPadding\` as padding on the label 1`] = `
       disabled={false}
       name="duck"
       onChange={[Function]}
+      onKeyPress={[Function]}
       required={false}
       type="radio"
     />
@@ -196,6 +199,7 @@ exports[`applies className corresponding to \`radioVerticalAlign\` on the label 
       disabled={false}
       name="duck"
       onChange={[Function]}
+      onKeyPress={[Function]}
       required={false}
       type="radio"
     />
@@ -255,6 +259,7 @@ exports[`if no \`children\` are passed in 1`] = `
       id="no-children"
       name="duck"
       onChange={[Function]}
+      onKeyPress={[Function]}
       required={false}
       type="radio"
     />
@@ -303,6 +308,7 @@ exports[`is checked when \`isChecked\` is set to true 1`] = `
       disabled={false}
       name="duck"
       onChange={[Function]}
+      onKeyPress={[Function]}
       required={false}
       type="radio"
     />
@@ -366,6 +372,7 @@ exports[`is not checked by default 1`] = `
       disabled={false}
       name="duck"
       onChange={[Function]}
+      onKeyPress={[Function]}
       required={false}
       type="radio"
     />
@@ -423,6 +430,7 @@ exports[`renders \`children\` passed in 1`] = `
       disabled={false}
       name="duck"
       onChange={[Function]}
+      onKeyPress={[Function]}
       required={false}
       type="radio"
     />
@@ -481,6 +489,7 @@ exports[`renders \`hasError\` state 1`] = `
       disabled={false}
       name="duck"
       onChange={[Function]}
+      onKeyPress={[Function]}
       required={false}
       type="radio"
     />
@@ -540,6 +549,7 @@ exports[`renders \`hasError\` state 2`] = `
       disabled={false}
       name="duck"
       onChange={[Function]}
+      onKeyPress={[Function]}
       required={false}
       type="radio"
     />
@@ -603,6 +613,7 @@ exports[`renders \`input\` within \`label\` 1`] = `
       disabled={false}
       name="duck"
       onChange={[Function]}
+      onKeyPress={[Function]}
       required={false}
       type="radio"
     />
@@ -660,6 +671,7 @@ exports[`renders radio input 1`] = `
       disabled={false}
       name="duck"
       onChange={[Function]}
+      onKeyPress={[Function]}
       required={false}
       type="radio"
     />

--- a/packages/thumbprint-react/components/Radio/index.tsx
+++ b/packages/thumbprint-react/components/Radio/index.tsx
@@ -104,10 +104,15 @@ export interface RadioProps {
      */
     labelPadding?: string;
     /**
-     * Function that runs when a new radio button is selected. It receives the new boolean value
-     * and the provided `id` as such: `props.onChange(e.target.checked, props.id)`.
+     * Function that runs when a new radio button is selected. It receives the new boolean value,
+     * the provided `id`, and the underlying `event` as such:
+     * `props.onChange(event.target.checked, props.id, event)`.
      */
-    onChange: (isChecked: boolean, id?: string) => void;
+    onChange: (
+        isChecked: boolean,
+        id: string | undefined,
+        event: React.ChangeEvent<HTMLInputElement>,
+    ) => void;
     /**
      * A selector hook into the React component for use in automated testing environments. It is
      * applied internally to the `<input />` element.
@@ -152,7 +157,7 @@ export default function Radio({
                 className={styles.input}
                 type="radio"
                 id={id}
-                onChange={(event): void => onChange(event.target.checked, id)}
+                onChange={(event): void => onChange(event.target.checked, id, event)}
                 checked={isChecked}
                 name={name}
                 disabled={isDisabled}

--- a/packages/thumbprint-react/components/Radio/index.tsx
+++ b/packages/thumbprint-react/components/Radio/index.tsx
@@ -114,6 +114,10 @@ export interface RadioProps {
         event: React.ChangeEvent<HTMLInputElement>,
     ) => void;
     /**
+     * Function that is called when the user presses a key while focused on the Radio.
+     */
+    onKeyPress?: (event: React.KeyboardEvent<HTMLInputElement>) => void;
+    /**
      * A selector hook into the React component for use in automated testing environments. It is
      * applied internally to the `<input />` element.
      */
@@ -135,6 +139,7 @@ export default function Radio({
     labelPadding = '14px 0',
     name,
     onChange,
+    onKeyPress = (): void => {},
     radioVerticalAlign = 'center',
 }: RadioProps): JSX.Element {
     const uiState = getUIState({ isChecked, isDisabled, hasError });
@@ -157,7 +162,12 @@ export default function Radio({
                 className={styles.input}
                 type="radio"
                 id={id}
-                onChange={(event): void => onChange(event.target.checked, id, event)}
+                onChange={(event): void => {
+                    onChange(event.target.checked, id, event);
+                }}
+                onKeyPress={(event): void => {
+                    onKeyPress(event);
+                }}
                 checked={isChecked}
                 name={name}
                 disabled={isDisabled}

--- a/packages/thumbprint-react/components/Radio/index.tsx
+++ b/packages/thumbprint-react/components/Radio/index.tsx
@@ -116,7 +116,7 @@ export interface RadioProps {
     /**
      * Function that is called when the user presses a key while focused on the Radio.
      */
-    onKeyPress?: (event: React.KeyboardEvent<HTMLInputElement>) => void;
+    onKeyDown?: (event: React.KeyboardEvent<HTMLInputElement>) => void;
     /**
      * A selector hook into the React component for use in automated testing environments. It is
      * applied internally to the `<input />` element.
@@ -139,7 +139,7 @@ export default function Radio({
     labelPadding = '14px 0',
     name,
     onChange,
-    onKeyPress = (): void => {},
+    onKeyDown = (): void => {},
     radioVerticalAlign = 'center',
 }: RadioProps): JSX.Element {
     const uiState = getUIState({ isChecked, isDisabled, hasError });
@@ -165,8 +165,8 @@ export default function Radio({
                 onChange={(event): void => {
                     onChange(event.target.checked, id, event);
                 }}
-                onKeyPress={(event): void => {
-                    onKeyPress(event);
+                onKeyDown={(event): void => {
+                    onKeyDown(event);
                 }}
                 checked={isChecked}
                 name={name}

--- a/packages/thumbprint-react/components/Radio/test.tsx
+++ b/packages/thumbprint-react/components/Radio/test.tsx
@@ -130,10 +130,18 @@ test('passes correct new value and `id` to `onChange` function', () => {
     );
 
     wrapper.find('input').simulate('change', { target: { checked: false } });
-    expect(onChange).toHaveBeenCalledWith(false, 'goose');
+    expect(onChange).toHaveBeenCalledWith(
+        false,
+        'goose',
+        expect.objectContaining({ type: 'change' }),
+    );
 
     wrapper.find('input').simulate('change', { target: { checked: true } });
-    expect(onChange).toHaveBeenCalledWith(true, 'goose');
+    expect(onChange).toHaveBeenCalledWith(
+        true,
+        'goose',
+        expect.objectContaining({ type: 'change' }),
+    );
 });
 
 test('adds `dataTest` prop', () => {

--- a/packages/thumbprint-react/components/TextInput/index.tsx
+++ b/packages/thumbprint-react/components/TextInput/index.tsx
@@ -244,6 +244,7 @@ export interface TextInputProps {
     onKeyUp?: (event: React.KeyboardEvent<HTMLInputElement>) => void;
     /**
      * Fires when a valid key input is made.
+     * @deprecated This event is deprecated in the DOM APIs. Use `onKeyDown` or `onKeyUp` instead.
      */
     onKeyPress?: (event: React.KeyboardEvent<HTMLInputElement>) => void;
     /**


### PR DESCRIPTION
- Pass event as third parameter to onChange prop of Radio and Checkbox
- Deprecate onKeyPress of TextInput