### PR TITLE
Add a `sr-only` class to Atomic

### DIFF
--- a/packages/thumbprint-atomic/CHANGELOG.md
+++ b/packages/thumbprint-atomic/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Added
+
+-   [Minor] Add a `sr-only` class for only displaying an element to a screen reader.
+
 ## 4.2.1 - 2022-05-09
 
 ### Changed

--- a/packages/thumbprint-atomic/__snapshots__/test.js.snap
+++ b/packages/thumbprint-atomic/__snapshots__/test.js.snap
@@ -652,6 +652,17 @@ _:-ms-lang(x) {
   table-layout: fixed !important;
   width: 100% !important;
 }
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}
 .flex {
   display: flex !important;
 }

--- a/packages/thumbprint-atomic/src/packages/display.scss
+++ b/packages/thumbprint-atomic/src/packages/display.scss
@@ -50,6 +50,18 @@
     width: 100% !important;
 }
 
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border-width: 0;
+}
+
 @include tp-respond-above($tp-breakpoint__small) {
     .s_dn {
         display: none !important;


### PR DESCRIPTION
This will allow us to add elements to the page that will only be visible to screen readers.

The CSS properties and values come from Tailwind:
https://tailwindcss.com/docs/screen-readers