### PR TITLE
Fixes link references to chip component

### DIFF
--- a/www/src/pages/components/pill/usage/index.mdx
+++ b/www/src/pages/components/pill/usage/index.mdx
@@ -18,7 +18,7 @@ import { ComponentHeader, ComponentFooter } from 'components/thumbprint-componen
 
 Used for quick visual recognition of user interface elements in a clear, concise, and contextual manner.
 
-`Pill`s are also considered read-only and are non-interactive in nature. See [Chip](/components/chip) component for an interactive element with with similar characteristics.
+`Pill`s are also considered read-only and are non-interactive in nature. See [Chip](/components/chip/react) component for an interactive element with with similar characteristics.
 
 ## Anatomy
 
@@ -148,8 +148,8 @@ You can use the icon parameter to provide additional accentuation in the messagi
 
 ## Related components
 
--   **[Chip](/components/chip)** - Compact controls that allow for toggling and filtering
--   **[Icons](https://thumbprint.thumbtack.io/icons)** - Assets for multiple platforms.
+-   **[Chip](/components/chip/react)** - Compact controls that allow for toggling and filtering
+-   **[Thumbprint Icons](https://thumbprint.thumbtack.io/icons)** - Assets for multiple platforms.
 
 export const pageQuery = graphql`
     {


### PR DESCRIPTION
The `react` reference to the Chip path was committed, and the current links are invalid.