### PR TITLE
Removes usage documentation for announcement modal

### DIFF
--- a/www/src/pages/components/modal/usage/index.mdx
+++ b/www/src/pages/components/modal/usage/index.mdx
@@ -166,36 +166,6 @@ There are two modal sizes; narrow and wide. Each take up a percentage of screen 
 
 A modal's height will grow to fit their content up to 50% of the screen's height. Beyond that, the content will scroll with in the modal.
 
-## Announcement modal
-
-These modals are for important announcements. They are best used as an entry point to focus all of the user's attention on a large or impactful update on the platform. They can also be followed by a series of popovers to highlight individual changes and benefits.
-
-<div className="center mt5" style={{ maxWidth: '530px' }}>
-    <Img src="./modal-announce.png" alt="Modal announce" />
-</div>
-
-### Anatomy
-
-#### 1. Curtain
-
-Covers the underlying content while providing focus to the information being served in the container. Note that there is no curtain below the small breakpoint.
-
-#### 2. Illustration
-
-Should always reinforce the message we are trying to communicate in the modal.
-
-#### 3. Title
-
-Reinforces context from the initial trigger on page while providing an overview of the modal.
-
-#### 4. Contents
-
-A concise description or simple action a user must address. If multiple steps are required, use a whole page instead.
-
-#### 5. Action bar
-
-Contains the primary action of the modal. Since it is the primary action, use the primary button. These actions should also contain hint text to provide even further context.
-
 <ComponentFooter data={props.data} />
 
 export const pageQuery = graphql`


### PR DESCRIPTION
Simple PR to remove documentation details for a modal approach that we currently do not offer.