### PR TITLE
Fix component platform navigation for Next.js

### DIFF
--- a/next/components/mdx/mdx.tsx
+++ b/next/components/mdx/mdx.tsx
@@ -76,11 +76,11 @@ export const MDXComponentPage = ({
             <TabNav>
                 {componentPageProps.componentPlatforms.map(platform => (
                     <TabNavItem
-                        isActive={platform === componentPageProps.platformId}
-                        key={platform}
-                        href={`/components/${componentPageProps.id}/${platform}`}
+                        isActive={platform.id === componentPageProps.platformId}
+                        key={platform.id}
+                        href={`/components/${componentPageProps.id}/${platform.id}`}
                     >
-                        {platform}
+                        {platform.name}
                     </TabNavItem>
                 ))}
             </TabNav>

--- a/next/utils/component-page-props.ts
+++ b/next/utils/component-page-props.ts
@@ -4,7 +4,7 @@ import { ComponentDefinition } from '../components/thumbprint-components/props-t
 export interface ComponentPageProps {
     id: string;
     platformId: string;
-    componentPlatforms: string[];
+    componentPlatforms: { id: string; name: string }[];
     packageTable: {
         name: string;
         version: string;

--- a/next/utils/component-page-props.ts
+++ b/next/utils/component-page-props.ts
@@ -4,7 +4,7 @@ import { ComponentDefinition } from '../components/thumbprint-components/props-t
 export interface ComponentPageProps {
     id: string;
     platformId: string;
-    componentPlatforms: { id: string; name: string }[];
+    componentPlatforms: { id: PlatformName; name: string }[];
     packageTable: {
         name: string;
         version: string;

--- a/next/utils/mdx-get-static-props.ts
+++ b/next/utils/mdx-get-static-props.ts
@@ -32,8 +32,39 @@ export default function getStaticProps(
         componentPlatforms = fs
             .readdirSync(`pages/components/${metadata.component.id}`)
             .map(file => {
-                // Remove `.mdx` from string
-                return file.replace('.mdx', '');
+                // Removes `.mdx` from filename
+                const platformId = file.replace('.mdx', '');
+
+                const displayName: Record<string, string> = {
+                    usage: 'Usage',
+                    react: 'React',
+                    scss: 'SCSS',
+                    ios: 'iOS (UIKit)',
+                    swiftui: 'iOS (SwiftUI)',
+                    android: 'Android',
+                };
+
+                // Return the filename as `platformId` as well as a display name for the platform.
+                return { id: platformId, name: displayName[platformId] };
+            })
+            .sort((a, b) => {
+                const platformOrder: Record<string, number> = {
+                    usage: 1,
+                    react: 2,
+                    scss: 3,
+                    ios: 4,
+                    swiftui: 5,
+                    android: 6,
+                };
+
+                if (!platformOrder[a.id] || !platformOrder[b.id]) {
+                    throw new Error(
+                        `All platforms must be defined in the \`platformOrder\` object.`,
+                    );
+                }
+
+                // Sorts the platforms the order that we want to display them.
+                return platformOrder[a.id] - platformOrder[b.id];
             });
 
         if (componentPlatforms.length === 0) {
@@ -117,7 +148,7 @@ export default function getStaticProps(
                           // these are all defined.
                           id: metadata.component.id as string,
                           platformId: metadata.component.platformId as string,
-                          componentPlatforms: componentPlatforms as string[],
+                          componentPlatforms: componentPlatforms as ComponentPageProps['componentPlatforms'],
                           packageTable,
                           componentDocgens,
                       },

--- a/next/utils/mdx-get-static-props.ts
+++ b/next/utils/mdx-get-static-props.ts
@@ -15,6 +15,12 @@ interface Metadata {
     };
 }
 
+type PlatformName = 'usage' | 'react' | 'scss' | 'ios' | 'swiftui' | 'android';
+
+function isPlatformName(str: string): str is PlatformName {
+    return ['usage', 'react', 'scss', 'ios', 'swiftui', 'android'].includes(str);
+}
+
 export default function getStaticProps(
     ctx: GetStaticPropsContext,
     metadata?: Metadata,
@@ -35,7 +41,7 @@ export default function getStaticProps(
                 // Removes `.mdx` from filename
                 const platformId = file.replace('.mdx', '');
 
-                const displayName: Record<string, string> = {
+                const displayName: Record<PlatformName, string> = {
                     usage: 'Usage',
                     react: 'React',
                     scss: 'SCSS',
@@ -44,11 +50,15 @@ export default function getStaticProps(
                     android: 'Android',
                 };
 
+                if (!isPlatformName(platformId)) {
+                    throw new Error(`All platforms must be defined in the \`displayName\` object.`);
+                }
+
                 // Return the filename as `platformId` as well as a display name for the platform.
                 return { id: platformId, name: displayName[platformId] };
             })
             .sort((a, b) => {
-                const platformOrder: Record<string, number> = {
+                const platformOrder: Record<PlatformName, number> = {
                     usage: 1,
                     react: 2,
                     scss: 3,

--- a/next/utils/mdx-get-static-props.ts
+++ b/next/utils/mdx-get-static-props.ts
@@ -50,7 +50,7 @@ export default function getStaticProps(
                     android: 'Android',
                 };
 
-                if (!isPlatformName(platformId)) {
+                if (!isPlatformName(platformId) || !displayName[platformId]) {
                     throw new Error(`All platforms must be defined in the \`displayName\` object.`);
                 }
 


### PR DESCRIPTION
The platform names are now sorted and have a display title.