### PR TITLE
Removes extra parentheses showing after do/don't tables

### DIFF
--- a/www/src/components/dodont/index.tsx
+++ b/www/src/components/dodont/index.tsx
@@ -139,14 +139,12 @@ export function DoDontTable({ examples, headerText, description }: DoDontPropTyp
                         </td>
                     </tr>
                 ))}
-                (
                 {description ? (
                     <tr>
                         <td>{description[0]}</td>
                         <td>{description[1]}</td>
                     </tr>
                 ) : null}
-                )
             </tbody>
         </table>
     );


### PR DESCRIPTION
An example can be seen below or on the [Inclusion and accessibility](https://thumbprint.design/overview/content-design/inclusion-and-accessibility/#example-plain-language-principles-and-techniques) content design page.

![image](https://user-images.githubusercontent.com/8153/219711404-2c49f06e-707c-415b-aaff-d89fb16f32ba.png)
