### PR TITLE
Move away from `Link` component in Gatsby

### DIFF
--- a/www/src/components/container/index.tsx
+++ b/www/src/components/container/index.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef } from 'react';
-import { Link, graphql, useStaticQuery } from 'gatsby';
+import { graphql, useStaticQuery } from 'gatsby';
 import { Helmet } from 'react-helmet';
 import '@thumbtack/thumbprint-atomic';
 import '@thumbtack/thumbprint-global-css';
@@ -177,14 +177,14 @@ export default function Container({
                             })}
                         >
                             <div className="ph3 pv4 flex-none z-1 bb b-gray-300 bg-gray-200">
-                                <Link to="/" className="db mb3">
+                                <a href="/" className="db mb3">
                                     <img
                                         src={thumbprintLogo}
                                         className="db"
                                         style={{ width: '130px', height: '22px' }}
                                         alt="Thumbprint logo"
                                     />
-                                </Link>
+                                </a>
 
                                 <DocSearch>
                                     {({ id }): JSX.Element => (

--- a/www/src/components/container/side-nav.tsx
+++ b/www/src/components/container/side-nav.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import { Link } from 'gatsby';
 import { Text } from '@thumbtack/thumbprint-react';
 import classNames from 'classnames';
 import ClickableBox from 'clickable-box';
@@ -101,19 +100,15 @@ export function SideNavLink({
                 {hash ? (
                     <ScrollMarkerLink id={hash}>
                         {({ isActive: isHashActive, onClick }): JSX.Element => (
-                            <Link
-                                className={getLinkClasses(isHashActive)}
-                                onClick={onClick}
-                                to={to}
-                            >
+                            <a className={getLinkClasses(isHashActive)} onClick={onClick} href={to}>
                                 {title}
-                            </Link>
+                            </a>
                         )}
                     </ScrollMarkerLink>
                 ) : (
-                    <Link className={getLinkClasses(isActive)} aria-current={isActive} to={to}>
+                    <a className={getLinkClasses(isActive)} aria-current={isActive} href={to}>
                         {title}
-                    </Link>
+                    </a>
                 )}
                 {children && (
                     // eslint-disable-next-line jsx-a11y/mouse-events-have-key-events

--- a/www/src/components/thumbprint-www/featured/index.tsx
+++ b/www/src/components/thumbprint-www/featured/index.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { Link } from 'gatsby';
 
 import helpSvg from './svg/help.svg';
 import colorSvg from './svg/color.svg';
@@ -11,8 +10,8 @@ export default function Featured(): JSX.Element {
     return (
         <div className="grid">
             <div className="m_col-6 mb3">
-                <Link
-                    to="/overview/about/"
+                <a
+                    href="/overview/about/"
                     className={`bg-white br2 black db h-100 color-inherit ${styles.shadow}`}
                 >
                     <div className="flex pv3 ph3 m_ph4 items-center">
@@ -26,11 +25,11 @@ export default function Featured(): JSX.Element {
                             </div>
                         </div>
                     </div>
-                </Link>
+                </a>
             </div>
             <div className="m_col-6 mb3">
-                <Link
-                    to="/guide/product/color/"
+                <a
+                    href="/guide/product/color/"
                     className={`bg-white br2 black db h-100 color-inherit ${styles.shadow}`}
                 >
                     <div className="flex pv3 ph3 m_ph4 items-center">
@@ -44,11 +43,11 @@ export default function Featured(): JSX.Element {
                             </div>
                         </div>
                     </div>
-                </Link>
+                </a>
             </div>
             <div className="m_col-6 mb3 m_mb0">
-                <Link
-                    to="/components/overview"
+                <a
+                    href="/components/overview"
                     className={`bg-white br2 black db h-100 color-inherit ${styles.shadow}`}
                 >
                     <div className="flex pv3 ph3 m_ph4 items-center">
@@ -62,11 +61,11 @@ export default function Featured(): JSX.Element {
                             </div>
                         </div>
                     </div>
-                </Link>
+                </a>
             </div>
             <div className="m_col-6">
-                <Link
-                    to="/help/"
+                <a
+                    href="/help/"
                     className={`bg-white br2 black db h-100 color-inherit ${styles.shadow}`}
                 >
                     <div className="flex pv3 ph3 m_ph4 items-center">
@@ -80,7 +79,7 @@ export default function Featured(): JSX.Element {
                             </div>
                         </div>
                     </div>
-                </Link>
+                </a>
             </div>
         </div>
     );

--- a/www/src/pages/components/alert/react/index.mdx
+++ b/www/src/pages/components/alert/react/index.mdx
@@ -3,7 +3,7 @@ title: Alert
 description: Vibrant alert messages used as page banners or within forms.
 ---
 
-import { graphql, Link } from 'gatsby';
+import { graphql } from 'gatsby';
 import {
     ComponentHeader,
     ComponentFooter,
@@ -15,7 +15,7 @@ import {
 ## Banner alerts
 
 <DeprecatedComponentAlert>
-    This component is deprecated. Use <Link to="/components/alert-banner/react/">AlertBanner</Link>{' '}
+    This component is deprecated. Use <a href="/components/alert-banner/react/">AlertBanner</a>{' '}
     instead.
 </DeprecatedComponentAlert>
 

--- a/www/src/pages/components/avatar/scss/index.mdx
+++ b/www/src/pages/components/avatar/scss/index.mdx
@@ -3,7 +3,7 @@ title: Avatar
 description: Display user images and badges on Thumbtack.
 ---
 
-import { graphql, Link } from 'gatsby';
+import { graphql } from 'gatsby';
 import {
     ComponentHeader,
     ComponentFooter,
@@ -23,9 +23,9 @@ import Alert from 'components/alert';
     >
         are out-of-date
     </a>
-    . <Link to="/components/avatar/react/">Use the React component</Link> if possible or <Link to="/help/">
+    . <a href="/components/avatar/react/">Use the React component</a> if possible or <a href="/help/">
         reach out to the Design Systems team
-    </Link> if you are blocked.
+    </a> if you are blocked.
 </Alert>
 
 ## Avatar Sizes

--- a/www/src/pages/components/grid/scss/index.mdx
+++ b/www/src/pages/components/grid/scss/index.mdx
@@ -3,7 +3,7 @@ title: Grid
 description: Responsive layouts, automatically aligned.
 ---
 
-import { graphql, Link } from 'gatsby';
+import { graphql } from 'gatsby';
 import {
     ComponentHeader,
     ComponentFooter,
@@ -14,7 +14,7 @@ import {
 
 <DeprecatedComponentAlert>
     This package was deprecated on September 11 in favor of classes from{' '}
-    <Link to="/atomic/#section-grid">Thumbprint Atomic</Link>.
+    <a href="/atomic/#section-grid">Thumbprint Atomic</a>.
 </DeprecatedComponentAlert>
 
 ## Overview

--- a/www/src/pages/components/modal-base/react/index.mdx
+++ b/www/src/pages/components/modal-base/react/index.mdx
@@ -3,7 +3,7 @@ title: Modal Base
 description: The basic modal functionality without any styles
 ---
 
-import { graphql, Link } from 'gatsby';
+import { graphql } from 'gatsby';
 import {
     ComponentHeader,
     ComponentFooter,
@@ -14,7 +14,7 @@ import {
 
 <DeprecatedComponentAlert>
     This package was deprecated in favor of{' '}
-    <Link to="/components/modal-curtain/react/">ModalCurtain</Link>.
+    <a href="/components/modal-curtain/react/">ModalCurtain</a>.
 </DeprecatedComponentAlert>
 
 ## Basic ModalBase

--- a/www/src/pages/components/modal-curtain/react/index.mdx
+++ b/www/src/pages/components/modal-curtain/react/index.mdx
@@ -3,7 +3,7 @@ title: Modal Curtain
 description: An overlay that contains content and covers the page
 ---
 
-import { graphql, Link } from 'gatsby';
+import { graphql } from 'gatsby';
 import { ComponentHeader, ComponentFooter } from 'components/thumbprint-components';
 import Alert from 'components/alert';
 import { InlineCode } from 'components/mdx';
@@ -12,7 +12,7 @@ import { InlineCode } from 'components/mdx';
 
 <Alert type="warning" title="Before using this component…">
     <InlineCode>ModalCurtain</InlineCode> is a low-level component that should only be used if the{' '}
-    <Link to="/components/modal/react/">Modal component</Link> is too restrictive. Please{' '}
+    <a href="/components/modal/react/">Modal component</a> is too restrictive. Please{' '}
     <a href="https://thumbtack.slack.com/archives/C7FLM0ZGU">
         reach out to the Design Systems team
     </a>{' '}

--- a/www/src/pages/components/modal-standard/react/index.mdx
+++ b/www/src/pages/components/modal-standard/react/index.mdx
@@ -3,7 +3,7 @@ title: Modal Standard
 description: A basic and commonly used modal.
 ---
 
-import { graphql, Link } from 'gatsby';
+import { graphql } from 'gatsby';
 import {
     ComponentHeader,
     ComponentFooter,
@@ -13,7 +13,7 @@ import {
 <ComponentHeader data={props.data} />
 
 <DeprecatedComponentAlert>
-    This package was deprecated in favor of <Link to="/components/modal/react/">Modal</Link>.
+    This package was deprecated in favor of <a href="/components/modal/react/">Modal</a>.
 </DeprecatedComponentAlert>
 
 ## Basic modal

--- a/www/src/pages/updates/notes/index.mdx
+++ b/www/src/pages/updates/notes/index.mdx
@@ -3,7 +3,7 @@ title: Release Notes
 description: Email newsletters from the Design Systems team.
 ---
 
-import { graphql, Link } from 'gatsby';
+import { graphql } from 'gatsby';
 import { Text } from '@thumbtack/thumbprint-react';
 import { UL, LI } from 'components/mdx';
 
@@ -33,9 +33,9 @@ export const pageQuery = graphql`
 <UL>
     {props.data.allMdx.edges.map(({ node }) => (
         <LI key={node.parent.name}>
-            <Link to={`/updates/notes/${node.parent.name}/`}>
+            <a href={`/updates/notes/${node.parent.name}/`}>
                 {node.frontmatter.title} {}
-            </Link>
+            </a>
         </LI>
     ))}
 </UL>


### PR DESCRIPTION
This turns off the SPA-like behavior in Gatsby. Page transitions will be slightly slower, but it means that users will always see the Next.js version of the page if it exists. The SPA-like behavior prevents the Next.js fallback from working 100% correctly.