### PR TITLE
Fix the `/components/overview/` page

### DIFF
--- a/next/next.config.js
+++ b/next/next.config.js
@@ -34,7 +34,7 @@ const nextConfig = {
     },
     async rewrites() {
         return {
-            beforeFiles: [
+            afterFiles: [
                 // Proxy everything except the homepage to the Gatsby version of the site.
                 // We will remove routes from this once they're ready to launch in Next.js.
                 {


### PR DESCRIPTION
We proxy some routes from Next.js to Gatsby, but we had it set as `beforeFiles`. This caused `/components/overview` to fail because the glob in one of the rewrites was catching it. Switching to `afterFiles` tells Next.js to only proxy if the page doesn't exist in Next.js.