### PR TITLE
Fixed types for the `Image` component

### DIFF
--- a/packages/thumbprint-react/CHANGELOG.md
+++ b/packages/thumbprint-react/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+-   [Patch] Fixed types for the `Image` component, acknowledging we spread `props` on a `picture` element (#940).
+
 ## 14.16.0 - 2023-06-08
 
 ### Changed

--- a/packages/thumbprint-react/components/Image/index.tsx
+++ b/packages/thumbprint-react/components/Image/index.tsx
@@ -22,7 +22,8 @@ type ImageSource = {
     srcSet: string;
 };
 
-export interface ImageProps {
+export interface ImageProps
+    extends React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement> {
     /**
      * If `sources` is provided, this image will be loaded by search engines and lazy-loaded for
      * users on browsers that don't support responsive images. If `sources` is not provided, this


### PR DESCRIPTION
We spread `props` on the `picture` element, but our types don't reflect that.

Fixes #940.