### PR TITLE
Fix types for Button component mouse and focus events

### DIFF
--- a/packages/thumbprint-react/CHANGELOG.md
+++ b/packages/thumbprint-react/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixed
+
+-   [Patch] Fixed types for Button component mouse and focus events
+
 ## 14.18.0 - 2023-11-09
 
 ### Added

--- a/packages/thumbprint-react/components/Button/index.tsx
+++ b/packages/thumbprint-react/components/Button/index.tsx
@@ -6,12 +6,12 @@ interface CommonProps {
     iconLeft?: React.ReactNode;
     iconRight?: React.ReactNode;
     isDisabled?: boolean;
-    onClick?: () => void;
-    onMouseEnter?: () => void;
-    onMouseOver?: () => void;
-    onFocus?: () => void;
-    onMouseLeave?: () => void;
-    onBlur?: () => void;
+    onClick?: (e: React.MouseEvent<HTMLElement>) => void;
+    onMouseEnter?: (e: React.MouseEvent<HTMLElement>) => void;
+    onMouseOver?: (e: React.MouseEvent<HTMLElement>) => void;
+    onFocus?: (e: React.FocusEvent<HTMLElement>) => void;
+    onMouseLeave?: (e: React.MouseEvent<HTMLElement>) => void;
+    onBlur?: (e: React.FocusEvent<HTMLElement>) => void;
     theme?: 'primary' | 'secondary' | 'tertiary' | 'inherit';
     type?: 'button' | 'submit';
     dataTest?: string;


### PR DESCRIPTION
These were supposed to have types but we never added them for some reason.