### PR TITLE
Fixes broken links to color usage documentation

### DIFF
--- a/next/components/thumbprint-www/featured/index.tsx
+++ b/next/components/thumbprint-www/featured/index.tsx
@@ -30,7 +30,7 @@ export default function Featured(): JSX.Element {
             </div>
             <div className="m_col-6 mb3">
                 <Link
-                    href="/guide/product/color/"
+                    href="/guide/product/color/overview/"
                     className={`bg-white br2 black db h-100 color-inherit ${styles.shadow}`}
                 >
                     <div className="flex pv3 ph3 m_ph4 items-center">

--- a/www/src/components/thumbprint-www/featured/index.tsx
+++ b/www/src/components/thumbprint-www/featured/index.tsx
@@ -29,7 +29,7 @@ export default function Featured(): JSX.Element {
             </div>
             <div className="m_col-6 mb3">
                 <a
-                    href="/guide/product/color/"
+                    href="/guide/product/color/overview/"
                     className={`bg-white br2 black db h-100 color-inherit ${styles.shadow}`}
                 >
                     <div className="flex pv3 ph3 m_ph4 items-center">

--- a/www/src/pages/updates/notes/2023-02-22.mdx
+++ b/www/src/pages/updates/notes/2023-02-22.mdx
@@ -40,7 +40,7 @@ With the most recent release, all [Thumbprint icons](https://thumbprint.thumbta
 
 ### 3. Color contrast ratio documentation on color usage page
 
-Thumbprint now offers [documentation on how to use each variation of our brand colors](/guide/product/color/#section-accessibility) in variety with one another to produce an accessible experience based on the WCAG 2.1 AA standards, along with a few general best practices for accessible color usage.
+Thumbprint now offers [documentation on how to use each variation of our brand colors](/guide/product/color/accessibility/) in variety with one another to produce an accessible experience based on the WCAG 2.1 AA standards, along with a few general best practices for accessible color usage.
 
 ## 📋 What’s coming up
 


### PR DESCRIPTION
Most notably, this fixes the featured link to color usage documentation on the home page.